### PR TITLE
Add final data to s3

### DIFF
--- a/scripts/process/simplify_wu_data.R
+++ b/scripts/process/simplify_wu_data.R
@@ -7,10 +7,24 @@ process.simplify_wu_data <- function(viz) {
   orig_wu_type_col <- deps[["col_names"]][["orig_names"]]
   new_wu_type_col <- deps[["col_names"]][["new_names"]]
   
-  columns_to_keep <- c("STATE", "STATEFIPS", "COUNTY", "COUNTYFIPS", "FIPS", "YEAR")
+  columns_to_keep <- c("STATE", "STATEFIPS", "COUNTY", "COUNTYFIPS", "FIPS", "YEAR") # also double as character cols
   columns_to_rename <- c("TP-TotPop", orig_wu_type_col)
   new_names <- c("countypop", new_wu_type_col)
   
+  # none of the columns we kept had characters (-- or N/A) that caused the entire column to
+  # be read in as character and needed to be converted back to numeric, but in case
+  # we add more data as we go along, here is the code that does that:
+  which_numeric_cols <- !names(wu_df) %in% columns_to_keep
+  numeric_data <- wu_df[, which_numeric_cols]
+  fixed_numeric_data <- as.data.frame(sapply(numeric_data, function(v) { 
+    has_missing_symbol <- grep("--|N/A", v)
+    v[has_missing_symbol] <- NA
+    v <- as.numeric(v)
+    return(v)
+  }))
+  wu_df[, which_numeric_cols] <- fixed_numeric_data
+  
+  # now select only the pertinent columns
   wu_df_sel <- wu_df[, c(columns_to_keep, columns_to_rename)]
   names(wu_df_sel) <- c(columns_to_keep, new_names)
   

--- a/scripts/s3_bucket_setup.R
+++ b/scripts/s3_bucket_setup.R
@@ -15,5 +15,5 @@ put_object(file='data/nhgis0002_shape.zip', object='IPUMS_NHGIS_counties.zip', b
 
 # this command posts the USGS WU mock up data from Google Drive (see pinned items in water-use-fy18-viz Slack channel)
 # had to delete the first row of info before uploading (version num + authors)
-put_object(file='data/usco2015-MockData-dataviz.xlsx', object='usco2015-MockData-dataviz.xlsx', bucket='viz-water-use-15')
+put_object(file='data/usco2015v2.0-dataviz.xlsx', object='usco2015v2.0-dataviz.xlsx', bucket='viz-water-use-15')
 

--- a/viz.yaml
+++ b/viz.yaml
@@ -102,7 +102,7 @@ fetch:
     id: wu_data_15
     location: cache/wu_data_15.xlsx
     fetch_args:
-      object_name: "usco2015-MockData-dataviz.xlsx"
+      object_name: "usco2015v2.0-dataviz.xlsx"
       bucket_name: "viz-water-use-15"
     reader: excel
     fetcher: s3_object


### PR DESCRIPTION
The new file is already pushed up to S3, this just integrates that with the rest of the viz. I did not delete the "mock" data from S3 because I didn't want it to break while others were working. Not sure if that is something we need to do or not.

We might need to add some other piece of processing based on the WU Team's feedback on what columns feed into which of the top-level categories (total, thermoelectric, public supply, irrigation, or industrial). I will create a separate issue for that if their feedback requires changes.

Fixes #13.