### PR TITLE
Url hash tags

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -40,7 +40,7 @@ d3.queue()
 var years = [1950, 1960, 1965, 1970, 1980, 1990, 1995, 2000, 2005, 2010, 2015];
 
 // Zoom status: default is nation-wide
-var activeView = getHash('v');
+var activeView = getHash('view');
 if(!activeView) activeView = 'USA';
 
 // Zoom year: start at 2015
@@ -48,7 +48,7 @@ var activeYear = d3.max(years);
 
 // Water use category: default is total. To make these readable in the URLs,
 // let's use full-length space-removed lower-case labels, e.g. publicsupply and thermoelectric
-var activeCategory = getHash('c');
+var activeCategory = getHash('category');
 if(!activeCategory) activeCategory = 'total';
 
 svg.append("text")
@@ -58,8 +58,8 @@ svg.append("text")
 
 // Initialize page info
 updateTitle();
-setHash('v', activeView);
-setHash('c', activeCategory);
+setHash('view', activeView);
+setHash('category', activeCategory);
 
 function create_map() {
 

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -39,15 +39,27 @@ d3.queue()
 // dummy var for now
 var years = [1950, 1960, 1965, 1970, 1980, 1990, 1995, 2000, 2005, 2010, 2015];
 
-// Zoom status: start at nation-wide, 2015
-var activeView = 'USA';
+// Zoom status: default is nation-wide
+var activeView = getHash('v');
+if(!activeView) activeView = 'USA';
+
+// Zoom year: start at 2015
 var activeYear = d3.max(years);
+
+// Water use category: default is total. To make these readable in the URLs,
+// let's use full-length space-removed lower-case labels, e.g. publicsupply and thermoelectric
+var activeCategory = getHash('c');
+if(!activeCategory) activeCategory = 'total';
 
 svg.append("text")
   .attr("id", "maptitle")
   .attr("x", chart_width/2)
   .attr("y", chart_height*0.10); // bring in 10% of chart height
+
+// Initialize page info
 updateTitle();
+setHash('v', activeView);
+setHash('c', activeCategory);
 
 function create_map() {
 

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -237,5 +237,5 @@ function updateCategory(category) {
 
 function updateTitle() {
   d3.select("#maptitle")
-    .text("Water Use Data for " + activeView + ", " + activeYear);
+    .text("Water Use Data for " + activeView + ", 2015, " + activeCategory);
 }

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -152,9 +152,8 @@ function updateView(newView) {
   // update the global variable that stores the current view
   activeView = newView;
   
+  // update page info
   updateTitle();
-
-  // update the URL with a #v=xxx so users can return to this view
   setHash('v', activeView);
 
   // determine the center point and scaling for the new view
@@ -226,6 +225,14 @@ function updateYear(year) {
   if(activeView !== 'USA') {
     showCounties(activeView);
   }
+}
+
+function updateCategory(category) {
+  activeCategory = category;
+  
+  // update page info
+  updateTitle();
+  setHash('c', activeCategory);
 }
 
 function updateTitle() {

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -86,7 +86,7 @@ function add_states(map, stateData) {
   };
 
   // if URL specifies a state view, zoom to that now
-  var newView = getHash('v');
+  var newView = getHash('view');
   if(newView == null) { newView = 'USA'; }
   if(newView != 'USA') {
     updateView(newView);
@@ -154,7 +154,7 @@ function updateView(newView) {
   
   // update page info
   updateTitle();
-  setHash('v', activeView);
+  setHash('view', activeView);
 
   // determine the center point and scaling for the new view
   var x, y, k;
@@ -232,7 +232,7 @@ function updateCategory(category) {
   
   // update page info
   updateTitle();
-  setHash('c', activeCategory);
+  setHash('category', activeCategory);
 }
 
 function updateTitle() {


### PR DESCRIPTION
Added URL hash tags for water use category. Tags for state were already there. Updated the map title function to reflect current category as well as state.

The default is USA, Total water use:
![180227-url-default](https://user-images.githubusercontent.com/12039957/36757569-2ce7d76c-1bcf-11e8-9968-4c8d84ebea21.gif)

You can call the `updateCategory` function in the browser to change the category in both the URL bar and the map title. (This is where @mwernimont can plug in the button functionality - buttons should call `updateCategory()`.)
![180227-function-call-zoom](https://user-images.githubusercontent.com/12039957/36757632-572ec17a-1bcf-11e8-8393-dd8273776510.gif)

And you can edit the URL directly, or paste in a new URL (not shown) to go to the specified state/national view and water use category:
![180227-url-edit-zoom](https://user-images.githubusercontent.com/12039957/36757695-7f71ad0a-1bcf-11e8-9b46-c103a444ff28.gif)
