### PR TITLE
downgrade SF for now for jenkins

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -37,7 +37,7 @@ info:
       version: 1.2.6
     sf:
       repo: CRAN
-      version: 0.6.0
+      version: 0.5.4
       
   contributors:
     -


### PR DESCRIPTION
this version was already installed for the GDP viz — seems we likely need to update GEOS to use the latest