### PR TITLE
Tooltips

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -17,12 +17,11 @@ var container = d3.select('body')
 
 // circle scale
 var scaleCircles = d3.scaleSqrt()
-  .range([0, 20])
+  .range([0, 20]);
 
 // Setup tooltips
 var tooltipDiv = d3.select("body").append("div")
-      .attr("class", "tooltip")
-      .style("opacity", 0);
+      .classed("tooltip hidden", true);
 
 // Create SVG
 var svg = d3.select("#content-container")

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -14,6 +14,11 @@ var buildPath = d3.geoPath()
 var scaleCircles = d3.scaleSqrt()
   .range([0, 20])
 
+// Setup tooltips
+var tooltipDiv = d3.select("body").append("div")
+      .attr("class", "tooltip")
+      .style("opacity", 0);
+
 // Create SVG
 var svg = d3.select("body")
     .append("svg")

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -2,6 +2,9 @@
 var chart_width     =   1000;
 var chart_height    =   700;
 
+// define categories
+var tempCategories = ["total", "thermoelectric", "publicsupply", "irrigation", "industrial"];
+
 // Projection
 var projection = albersUsaPr()
     .scale([1200])
@@ -49,9 +52,6 @@ d3.queue()
   .defer(d3.json, "data/county_centroids.json")
   .await(create_map);
 
-// dummy var for now
-var years = [1950, 1960, 1965, 1970, 1980, 1990, 1995, 2000, 2005, 2010, 2015];
-
 // Zoom status: default is nation-wide
 var activeView = getHash('view');
 if(!activeView) activeView = 'USA';
@@ -96,8 +96,6 @@ function create_map() {
 
 }
 
-var tempCategories = ["Total", "Thermoelectric", "Public Supply", "Irrigation", "Industrial"];
-
 var buttonContainer = d3.select('#content-container')
   .append('div')
   .attr('id', 'button-container');
@@ -126,11 +124,10 @@ var categoryButtons = d3.select('#button-container')
   .enter()
   .append('button')
   .text(function(d){
-    return d;
+    return categoryToName(d);
   })
   .attr('class', function(d){
-    var name = d.split(' ');
-    return name[0];
+    return d;
   })
   .on('click', function(d){
     updateCategory(d.toLowerCase());

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -64,7 +64,7 @@ function addCentroids(map, countyCentroids) {
     .attr("r", function(d) { 
       return scaleCircles(d.properties[[activeCategory]]);
     })
-    .on("mouseover", function(d) { seeTooltip(this, d); })
+    .on("mouseover", function(d) { showToolTip(this, d); })
     .on("mouseout", function(d) { hideTooltip(this, d); })
     .style("fill", 'purple')
     .style("opacity", 0.8); // adding this line made it super slow
@@ -260,7 +260,7 @@ function updateCircles(activeCategory) {
       .attr("r", function(d) { return scaleCircles(d.properties[[activeCategory]]); });
 }
 
-function seeTooltip(currentCircle, d) {
+function showToolTip(currentCircle, d) {
   var orig = d3.select(currentCircle),
       origNode = orig.node();
   var duplicate = d3.select(origNode.parentNode.appendChild(origNode.cloneNode(true), 

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -307,15 +307,6 @@ d3.selection.prototype.moveToFront = function() {
       });
     };
 
-function categoryToClass(category) {
-  if (category == "total") { return "Total"; }
-  else if (category == "thermoelectric") { return "Thermoelectric"; }
-  else if (category == "publicsupply") { return "Public"; }
-  else if (category == "irrigation") { return "Irrigation"; }
-  else if (category == "industrial") { return "Industrial"; }
-  else { return "none"; }
-}
-
 function categoryToName(category) {
   if (category == "total") { return "Total"; }
   else if (category == "thermoelectric") { return "Thermoelectric"; }

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -286,7 +286,8 @@ function seeTooltip(currentCircle, d) {
   d3.select(".tooltip")
     .html(d.properties.COUNTY + "<br/>" + 
             "Population: " + d.properties.countypop + "<br/>" +
-            activeCategory + ": " + d.properties[[activeCategory]] + " " + "MGD");
+            categoryToName(activeCategory) + ": " + 
+              d.properties[[activeCategory]] + " " + "MGD");
 }
 
 function hideTooltip(currentCircle, d) {
@@ -315,3 +316,21 @@ d3.selection.prototype.moveToBack = function() {
         } 
     });
 };
+
+function categoryToClass(category) {
+  if (category == "total") { return "Total"; }
+  else if (category == "thermoelectric") { return "Thermoelectric"; }
+  else if (category == "publicsupply") { return "Public"; }
+  else if (category == "irrigation") { return "Irrigation"; }
+  else if (category == "industrial") { return "Industrial"; }
+  else { return "none"; }
+}
+
+function categoryToName(category) {
+  if (category == "total") { return "Total"; }
+  else if (category == "thermoelectric") { return "Thermoelectric"; }
+  else if (category == "publicsupply") { return "Public Supply"; }
+  else if (category == "irrigation") { return "Irrigation"; }
+  else if (category == "industrial") { return "Industrial"; }
+  else { return "none"; }
+}

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -64,6 +64,8 @@ function addCentroids(map, countyCentroids) {
     .attr("r", function(d) { 
       return scaleCircles(d.properties[[activeCategory]]);
     })
+    .on("mouseover", function(d) { seeTooltip(this, d); })
+    .on("mouseout", function(d) { hideTooltip(this, d); })
     .style("fill", 'purple')
     .style("stroke", 'none');
 }
@@ -256,4 +258,30 @@ function updateCircles(activeCategory) {
         return d3.descending(a.properties[[activeCategory]], b.properties[[activeCategory]]);
       })
       .attr("r", function(d) { return scaleCircles(d.properties[[activeCategory]]); });
+}
+
+function seeTooltip(currentCircle, d) {
+  d3.select(currentCircle)
+    .style("opacity", 0.7);
+  d3.select(".tooltip")
+    .transition()
+    .duration(50)
+    .style("display", "block")
+		.style("position", "absolute")
+    .style("opacity", 0.9)
+    .style("left", (d3.event.pageX + 35) + "px")
+    .style("top", (d3.event.pageY - 50) + "px");
+  d3.select(".tooltip")
+    .html(d.properties.COUNTY + "<br/>" + 
+            "Population" + d.properties.countypop + "<br/>" +
+            activeCategory + d.properties[[activeCategory]] + "million gallons/day");
+}
+
+function hideTooltip(currentCircle, d) {
+  d3.select(currentCircle)
+    .style("opacity", 1);
+  d3.select(".tooltip")
+    .transition()
+    .duration(100)
+    .style("opacity", 0);
 }

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -306,16 +306,6 @@ d3.selection.prototype.moveToFront = function() {
         this.parentNode.appendChild(this);
       });
     };
-    
-d3.selection.prototype.moveToBack = function() {  
-    return this.each(function() { 
-      console.log(this.parentNode);
-        var firstChild = this.parentNode.firstChild; 
-        if (firstChild) { 
-            this.parentNode.insertBefore(this, firstChild); 
-        } 
-    });
-};
 
 function categoryToClass(category) {
   if (category == "total") { return "Total"; }

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -67,7 +67,7 @@ function addCentroids(map, countyCentroids) {
     .on("mouseover", function(d) { seeTooltip(this, d); })
     .on("mouseout", function(d) { hideTooltip(this, d); })
     .style("fill", 'purple')
-    .style("stroke", 'none');
+    .style("stroke", 'black');
 }
 
 // Create the state polygons
@@ -262,6 +262,7 @@ function updateCircles(activeCategory) {
 
 function seeTooltip(currentCircle, d) {
   d3.select(currentCircle)
+    .moveToFront()
     .style("opacity", 0.7);
   d3.select(".tooltip")
     .transition()
@@ -279,9 +280,26 @@ function seeTooltip(currentCircle, d) {
 
 function hideTooltip(currentCircle, d) {
   d3.select(currentCircle)
+    .moveToBack()
     .style("opacity", 1);
   d3.select(".tooltip")
     .transition()
     .duration(100)
     .style("opacity", 0);
 }
+
+d3.selection.prototype.moveToFront = function() {  
+      return this.each(function(){
+        this.parentNode.appendChild(this);
+      });
+    };
+    
+d3.selection.prototype.moveToBack = function() {  
+    return this.each(function() { 
+      console.log(this.parentNode);
+        var firstChild = this.parentNode.firstChild; 
+        if (firstChild) { 
+            this.parentNode.insertBefore(this, firstChild); 
+        } 
+    });
+};

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -276,11 +276,10 @@ function seeTooltip(currentCircle, d) {
   
   // change tooltip
   d3.select(".tooltip")
+    .classed("shown", true)
+    .classed("hidden", false)
     .transition()
     .duration(50)
-    .style("display", "block")
-		.style("position", "absolute")
-    .style("opacity", 0.9)
     .style("left", (d3.event.pageX + 35) + "px")
     .style("top", (d3.event.pageY - 50) + "px");
   d3.select(".tooltip")
@@ -296,9 +295,10 @@ function hideTooltip(currentCircle, d) {
   d3.select('.county-point-duplicate')
     .remove(); // delete duplicate
   d3.select(".tooltip")
+    .classed("shown", false)
+    .classed("hidden", true)
     .transition()
-    .duration(100)
-    .style("opacity", 0);
+    .duration(100);
 }
 
 d3.selection.prototype.moveToFront = function() {  

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -67,7 +67,7 @@ function addCentroids(map, countyCentroids) {
     .on("mouseover", function(d) { seeTooltip(this, d); })
     .on("mouseout", function(d) { hideTooltip(this, d); })
     .style("fill", 'purple')
-    .style("stroke", 'black');
+    .style("opacity", 0.8); // adding this line made it super slow
 }
 
 // Create the state polygons
@@ -261,9 +261,20 @@ function updateCircles(activeCategory) {
 }
 
 function seeTooltip(currentCircle, d) {
-  d3.select(currentCircle)
-    .moveToFront()
-    .style("opacity", 0.7);
+  var orig = d3.select(currentCircle),
+      origNode = orig.node();
+  var duplicate = d3.select(origNode.parentNode.appendChild(origNode.cloneNode(true), 
+                                                            origNode.nextSibling));
+  
+  // style circles
+  orig
+    .style("opacity", 0); // makes original circle invisible in the background
+  duplicate
+    .classed('county-point-duplicate', true)
+    .style("pointer-events", "none")
+    .style("opacity", 1); // makes the duplicate circle on the top
+  
+  // change tooltip
   d3.select(".tooltip")
     .transition()
     .duration(50)
@@ -274,14 +285,15 @@ function seeTooltip(currentCircle, d) {
     .style("top", (d3.event.pageY - 50) + "px");
   d3.select(".tooltip")
     .html(d.properties.COUNTY + "<br/>" + 
-            "Population" + d.properties.countypop + "<br/>" +
-            activeCategory + d.properties[[activeCategory]] + "million gallons/day");
+            "Population: " + d.properties.countypop + "<br/>" +
+            activeCategory + ": " + d.properties[[activeCategory]] + " " + "MGD");
 }
 
 function hideTooltip(currentCircle, d) {
   d3.select(currentCircle)
-    .moveToBack()
-    .style("opacity", 1);
+    .style("opacity", 0.8);
+  d3.select('.county-point-duplicate')
+    .remove(); // delete duplicate
   d3.select(".tooltip")
     .transition()
     .duration(100)

--- a/layout/css/main.css
+++ b/layout/css/main.css
@@ -70,23 +70,23 @@ body {
     opacity:1;
   }
   
-  .Total{
+  .total{
     background:rgb(46, 134, 171);
   }
   
-  .Thermoelectric{
+  .thermoelectric{
     background:rgb(252,186,4);
   }
   
-  .Public{
+  .publicsupply{
     background:rgb(186,50,40);
   }
   
-  .Irrigation{
+  .irrigation{
     background:rgb(155,197,61);
   }
   
-  .Industrial{
+  .industrial{
     background:rgb(138,113,106);
   }
 }

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -36,3 +36,19 @@
 .dragging {
   cursor: move; /* was using grabbing, but that only works in Firefox*/
 }
+
+.tooltip {
+	  position: absolute;
+  	padding: 5px;
+  	background-color: white;
+  	border-radius: 10px;
+  	box-shadow: 4px 4px 10px rgba(0, 0, 0, 0.4);
+}
+
+.hidden {
+	display: none;
+}
+
+.shown {
+	display: block;
+}


### PR DESCRIPTION
What this adds: tooltip with info about county name, population, and water use value. Circle that is being hovered on changes to opacity 1 (rather than 0.8) and is brought to the front. When the mouse moves away, the circle goes back to it's original position (functionally, a duplicate is being made and then deleted). For some reason, the hovers became slow when I added an initial opacity (commented that in the line).

For now this is the rest of #35. Performance can be worked on with #19.

![image](https://user-images.githubusercontent.com/13220910/36865035-f95da88c-1d53-11e8-9474-67fea4813956.png)
