### PR TITLE
First iteration of pie charts in d3.

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -61,6 +61,8 @@ if(!activeView) activeView = 'USA';
 // let's use full-length space-removed lower-case labels, e.g. publicsupply and thermoelectric
 var activeCategory = getHash('category');
 if(!activeCategory) activeCategory = 'total';
+// default for prev is total
+var prevCategory = 'total';
 
 svg.append("text")
   .attr("id", "maptitle")
@@ -129,12 +131,13 @@ var categoryButtons = d3.select('#button-container')
     return d;
   })
   .on('click', function(d){
+    prevCategory = activeCategory;
     activeCategory = d.toLowerCase(); // put this here so it only changes on click
     updateCategory(activeCategory);
   })
   .on('mouseover', function(d){
-    updateCategory(d.toLowerCase());
+    updateCategory(d.toLowerCase(), activeCategory);
   })
   .on('mouseout', function(d){
-    updateCategory(activeCategory);
+    updateCategory(activeCategory, d.toLowerCase());
   });

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -3,7 +3,8 @@ var chart_width     =   1000;
 var chart_height    =   700;
 
 // define categories
-var tempCategories = ["total", "thermoelectric", "publicsupply", "irrigation", "industrial"];
+var tempCategories = ["total", "thermoelectric", "publicsupply", 
+                      "irrigation", "industrial", "piechart"];
 
 // Projection
 var projection = albersUsaTerritories()

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -43,24 +43,13 @@ function addCentroids(map, countyCentroids) {
     })
     .attr('fips', function(d) { return d.properties.GEOID; })
     .text(function(d) { return d.properties.GEOID; })
-    .attr("cx", function(d) { 
-      var proj = projection(d.geometry.coordinates);
-      if(!proj) {
-        console.log('bad projection:');
-        console.log(d);
-        console.log(projection(d.geometry.coordinates));
-        return 0;
-      } else {
-        return projection(d.geometry.coordinates)[0]; 
-      }
+    .attr("cx", function(d) {
+      var coordx = projectX(d.geometry.coordinates);
+      if(coordx === 0) { console.log(d); } // moved outside of project function bc coordinates aren't always d.geometry.coordinates (like in pies)
+      return coordx;
     })
     .attr("cy", function(d) { 
-      var proj = projection(d.geometry.coordinates);
-      if(!proj) {
-        return 0;
-      } else {
-        return projection(d.geometry.coordinates)[1]; 
-      }
+      return projectY(d.geometry.coordinates)
     })
     .attr("r", function(d) { 
       return scaleCircles(d.properties[[activeCategory]]);
@@ -332,3 +321,23 @@ function categoryToColor(category) {
   else { return "none"; }
 }
 
+// projection functions to catch and log bad ones
+function projectX(coordinates) {
+  var proj = projection(coordinates);
+  if(!proj) {
+    console.log('bad projection:');
+    console.log(projection(coordinates));
+    return 0;
+  } else {
+    return projection(coordinates)[0]; 
+  }
+}
+
+function projectY(coordinates) {
+  var proj = projection(coordinates);
+  if(!proj) {
+    return 0;
+  } else {
+    return projection(coordinates)[1]; 
+  }
+}

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -235,12 +235,21 @@ function updateView(newView) {
 
 function updateCategory(category) {
   
+  if (category === "piechart") {
+    
+    addPieCharts();
+    
+  } else {
+  
   // update circles
   updateCircles(category);
+    
+  }
   
   // update page info
   updateTitle(category);
   setHash('category', category);
+  
 }
 
 function updateTitle(category) {
@@ -309,6 +318,7 @@ function categoryToName(category) {
   else if (category == "publicsupply") { return "Public Supply"; }
   else if (category == "irrigation") { return "Irrigation"; }
   else if (category == "industrial") { return "Industrial"; }
+  else if (category == "piechart") { return "Pie Chart"; }
   else { return "none"; }
 }
 
@@ -318,5 +328,7 @@ function categoryToColor(category) {
   else if (category == "publicsupply") { return "rgba(186,50,40, 0.8)"; }
   else if (category == "irrigation") { return "rgba(155,197,61, 0.8)"; }
   else if (category == "industrial") { return "rgba(138,113,106, 0.8)"; }
+  else if (category == "other") { return "rgba(211,211,211, 0.8)"; }
   else { return "none"; }
 }
+

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -332,7 +332,7 @@ function categoryToColor(category) {
   else if (category == "publicsupply") { return "rgba(186,50,40, 0.8)"; }
   else if (category == "irrigation") { return "rgba(155,197,61, 0.8)"; }
   else if (category == "industrial") { return "rgba(138,113,106, 0.8)"; }
-  else if (category == "other") { return "rgba(211,211,211, 0.8)"; }
+  else if (category == "other") { return "rgba(143,73,186, 0.8)"; }
   else { return "none"; }
 }
 

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -222,16 +222,31 @@ function updateView(newView) {
       "translate(" + -x + "," + -y + ")");
 }
 
-function updateCategory(category) {
+function updateCategory(category, prevCategory) {
   
   if (category === "piechart") {
     
+    // shrink circles
+    d3.selectAll(".county-point")
+      .transition(500)
+      .attr("r", 0);
+  
     addPieCharts();
     
-  } else {
+  } else if(prevCategory === "piechart") {
   
+  // shrink pies
+  d3.selectAll(".pieslice")
+    .transition(500)
+    .attr("d", arcpath.outerRadius(0));
+    
   // update circles
   updateCircles(category);
+    
+  } else {
+    
+    // update circles
+    updateCircles(category);
     
   }
   

--- a/js/pie_utils.js
+++ b/js/pie_utils.js
@@ -1,0 +1,75 @@
+// functions related to the pie charts
+
+var pie = d3.pie()
+    .sort(null)
+    .value(function(d) { return d.value; });
+
+var arcpath = d3.arc()
+    .innerRadius(0);
+
+function addPieCharts() {
+  
+  // relies on map and countyCentroids as global vars
+   
+  var pieformdata = pieData(countyCentroids);
+  console.log(pieformdata);
+  
+  var piearc = map.selectAll('pie')
+    .data(pieformdata)
+    .enter()
+    .append('g')
+      .classed("pie", true)
+      .attr("data-totalwu", function (d) {
+        //include as attribute to use for outerRadius for each arc
+        //when arcs are added data is already subsetted to just the single category
+        //but they need to use "total" to set the outer radius
+        return d.piechartmeta[1]; 
+      })
+      .attr("transform", function(d) {
+        var coords = projection(d.piechartmeta[0]); // need to add projection thing for missing.
+        return "translate("+coords[0]+","+coords[1]+")";
+      });
+      
+  piearc.selectAll('path')  
+      .data(function(d) {
+        return pie(d.piechartdata);
+      })
+      .enter()
+      .append("path")
+        .attr("d", arcpath.outerRadius(function(d) {
+          var totalwuvalue = +d3.select(this.parentNode).attr("data-totalwu");
+          return scaleCircles(totalwuvalue);
+        }))
+        .attr("fill", function(d) { 
+          return categoryToColor(d.data.category); 
+        });
+  
+}
+
+
+function pieData(geodata) {
+  
+  var pieAll = [];
+  
+    for (var i=0; i<geodata.features.length; i++) {
+        pieAll.push( {
+          piechartdata: [
+            {"category": "thermoelectric", 
+                "value": parseInt(geodata.features[i].properties.thermoelectric)},
+            {"category": "publicsupply", 
+                "value": parseInt(geodata.features[i].properties.publicsupply)},
+            {"category": "irrigation", 
+                "value": parseInt(geodata.features[i].properties.irrigation)},
+            {"category": "industrial", 
+                "value": parseInt(geodata.features[i].properties.industrial)},
+            {"category": "other", 
+                "value": parseInt(geodata.features[i].properties.other)}],
+          piechartmeta: [
+            geodata.features[i].geometry.coordinates,
+            parseInt(geodata.features[i].properties.total)
+          ]
+        });
+    }
+    
+  return pieAll;
+}

--- a/js/pie_utils.js
+++ b/js/pie_utils.js
@@ -37,6 +37,8 @@ function addPieCharts() {
       })
       .enter()
       .append("path")
+        .classed("pieslice", true)
+        .transition(500)
         .attr("d", arcpath.outerRadius(function(d) {
           var totalwuvalue = +d3.select(this.parentNode).attr("data-totalwu");
           return scaleCircles(totalwuvalue);

--- a/js/pie_utils.js
+++ b/js/pie_utils.js
@@ -31,7 +31,7 @@ function addPieCharts() {
         return "translate("+xcoord+","+ycoord+")";
       });
       
-  piearc.selectAll('path')  
+  piearc.selectAll('pieslice')  
       .data(function(d) {
         return pie(d.piechartdata);
       })

--- a/js/pie_utils.js
+++ b/js/pie_utils.js
@@ -26,8 +26,9 @@ function addPieCharts() {
         return d.piechartmeta[1]; 
       })
       .attr("transform", function(d) {
-        var coords = projection(d.piechartmeta[0]); // need to add projection thing for missing.
-        return "translate("+coords[0]+","+coords[1]+")";
+        var xcoord = projectX(d.piechartmeta[0]),
+            ycoord = projectY(d.piechartmeta[0]);
+        return "translate("+xcoord+","+ycoord+")";
       });
       
   piearc.selectAll('path')  
@@ -45,7 +46,6 @@ function addPieCharts() {
         });
   
 }
-
 
 function pieData(geodata) {
   

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -52,6 +52,10 @@
   button.industrial{
     background:rgb(138,113,106);
   }
+  
+  button.piechart{
+    background:rgb(143,73,186);
+  }
 
 .legend {
   fill: none;

--- a/scripts/process/merge_centroids_wu.R
+++ b/scripts/process/merge_centroids_wu.R
@@ -6,7 +6,10 @@ process.merge_centroids_wu <- function(viz) {
   # merge datasets and keep a minimal set of columns
   centroids_data <- centroids_topo@data %>%
     left_join(wu_data_15_simple, by=c('GEOID'='FIPS')) %>%
-    select(GEOID, STATE_ABBV, COUNTY, countypop:industrial)
+    select(GEOID, STATE_ABBV, COUNTY, countypop:industrial) %>% 
+    rowwise() %>% 
+    mutate(other = total - sum(thermoelectric, publicsupply, irrigation, industrial))
+  
   centroids_topo@data <- centroids_data
   
   # write to file

--- a/viz.yaml
+++ b/viz.yaml
@@ -192,6 +192,7 @@ publish:
       projection: "custom_projection"
       map_utils: "map_utils"
       legend_utils: "legend_utils"
+      pie_utils: "pie_utils"
       map_counties: "map_counties"
       map: "build_map"
       state_boundaries: "state_boundaries_topojson"
@@ -200,7 +201,8 @@ publish:
       wu_data_15_range:  "wu_data_15_range_json"
     context:
       resources: ["lib_d3_js", "topojson", "header_css", "content_css", "footer_css", "socialCSS",
-                  "map_css", "custom_css", "hashes", "projection", "map_utils", "map_counties", "legend_utils"]
+                  "map_css", "custom_css", "hashes", "projection", "map_utils", "map_counties", 
+                  "legend_utils", "pie_utils"]
       sections: ["social","map","description_text", "directions_text"] # adding header and footer here, doubled each on the page
   -
     id: topojson
@@ -226,6 +228,10 @@ publish:
   -
     id: legend_utils
     location: "js/legend_utils.js"
+    mimetype: application/javascript
+  -
+    id: pie_utils
+    location: "js/pie_utils.js"
     mimetype: application/javascript
   -
     id: map_counties
@@ -282,6 +288,7 @@ publish:
       projection: custom_projection
       map_utils: map_utils
       legend_utils: legend_utils
+      pie_utils: pie_utils
       map_counties: map_counties
       map: build_map
       directions_text: directions_text
@@ -291,7 +298,8 @@ publish:
       wu_data_15_range:  wu_data_15_range_json
     context:
       resources: ["lib_d3_js", "topojson", 
-                  "map_css", "custom_css", "hashes", "projection", "map_utils", "map_counties", "legend_utils"]
+                  "map_css", "custom_css", "hashes", "projection", "map_utils", 
+                  "map_counties", "legend_utils", "pie_utils"]
       embed: ["map","directions_text"]
   -
     id: description_text


### PR DESCRIPTION
Working on #71. Not sure if this counts for "basic transitions" or not. Someone else can take over from here for next week.

The data reformatting should probably happen elsewhere, but I'm not exactly sure how to make that happen in R. We need an array where you can point to one "column" where all of the values for determining pie slice size are.

E.g. right now you get the size of the circle by saying `d.thermoelectric`, but we need to be able to say `d.value` and have that apply to all water use types.

If we want windshield wiper transitions and follow my idea in #72 where we just make all of them pie charts, then I think we can just format the data this way in R and not worry about it. I guess we could also format it this way and change the way we are calling it for individual categories, too.

Transitions between pie charts and other categories need work. Tried to make them smooth, but that didn't seem to do anything. I also tried to distinguish transitions between regular categories vs a single category to pie or pie to a single category. You'll see that effort in the function `updateCategory`.

Performance issue: as of now, it appears that every time you click or hover on category, completely new pie groups are being added rather than updated. The goal would to only have a total of 2x number of counties in the group with id `map` (one set of circles, one set of pie groups). But it just keeps growing if you keep changing categories. I've made note of this in #82.

![piecharts](https://user-images.githubusercontent.com/13220910/37539787-b46e244c-2922-11e8-9af4-ac1cf71bc79c.gif)
