### PR TITLE
Text has no margin

### DIFF
--- a/layout/templates/textSection.mustache
+++ b/layout/templates/textSection.mustache
@@ -1,0 +1,4 @@
+<div class="viz-text">
+  {{{directions}}}
+  {{{description}}}
+</div>

--- a/viz.yaml
+++ b/viz.yaml
@@ -179,8 +179,9 @@ publish:
       custom_css: "custom_css"
       social: "social_section"
       socialCSS: "lib-social-media-css"
+      description_text: "description_text"
+      directions_text: "directions_text"
       header: "header_section"
-      text_section: "text_section"
       footer: "footer_section"
       hashes: "url_hashes"
       projection: "custom_projection"
@@ -197,7 +198,7 @@ publish:
       resources: ["lib_d3_js", "topojson", "header_css", "content_css", "footer_css", "socialCSS",
                   "map_css", "custom_css", "hashes", "projection", "map_utils", "map_counties", 
                   "legend_utils", "pie_utils"]
-      sections: ["social", "map", "text_section"] # adding header and footer here, doubled each on the page
+      sections: ["social","map","description_text", "directions_text"] # adding header and footer here, doubled each on the page
   -
     id: topojson
     location: "js/topojson.v1.min.js"
@@ -247,14 +248,6 @@ publish:
     context:
       title: "Water use in the U.S. from 1950 to 2015"
   -
-    id: text_section
-    template: layout/templates/textSection.mustache
-    publisher: section
-    depends: description_text_md
-    context:
-      directions: description_text_md.directions_text-markdown
-      description: description_text_md.description_text-markdown
-  -
     id: footer_section
     template: footer-template
     publisher: footer
@@ -291,9 +284,9 @@ publish:
       map_utils: map_utils
       legend_utils: legend_utils
       pie_utils: pie_utils
-      text_section: text_section
       map_counties: map_counties
       map: build_map
+      directions_text: directions_text
       state_boundaries: state_boundaries_topojson
       county_boundaries: county_boundaries_topojson
       county_centroids_wu: county_centroids_wu_topojson
@@ -302,4 +295,18 @@ publish:
       resources: ["lib_d3_js", "topojson", 
                   "map_css", "custom_css", "hashes", "projection", "map_utils", 
                   "map_counties", "legend_utils", "pie_utils"]
-      embed: ["map", "text_section"]
+      embed: ["map","directions_text"]
+  -
+    id: description_text
+    template: printall
+    publisher: section
+    depends: description_text_md
+    context:
+      text: description_text_md.description_text-markdown
+  -
+    id: directions_text
+    template: printall
+    publisher: section
+    depends: description_text_md
+    context:
+      text: description_text_md.directions_text-markdown

--- a/viz.yaml
+++ b/viz.yaml
@@ -179,9 +179,8 @@ publish:
       custom_css: "custom_css"
       social: "social_section"
       socialCSS: "lib-social-media-css"
-      description_text: "description_text"
-      directions_text: "directions_text"
       header: "header_section"
+      text_section: "text_section"
       footer: "footer_section"
       hashes: "url_hashes"
       projection: "custom_projection"
@@ -198,7 +197,7 @@ publish:
       resources: ["lib_d3_js", "topojson", "header_css", "content_css", "footer_css", "socialCSS",
                   "map_css", "custom_css", "hashes", "projection", "map_utils", "map_counties", 
                   "legend_utils", "pie_utils"]
-      sections: ["social","map","description_text", "directions_text"] # adding header and footer here, doubled each on the page
+      sections: ["social", "map", "text_section"] # adding header and footer here, doubled each on the page
   -
     id: topojson
     location: "js/topojson.v1.min.js"
@@ -248,6 +247,14 @@ publish:
     context:
       title: "Water use in the U.S. from 1950 to 2015"
   -
+    id: text_section
+    template: layout/templates/textSection.mustache
+    publisher: section
+    depends: description_text_md
+    context:
+      directions: description_text_md.directions_text-markdown
+      description: description_text_md.description_text-markdown
+  -
     id: footer_section
     template: footer-template
     publisher: footer
@@ -284,9 +291,9 @@ publish:
       map_utils: map_utils
       legend_utils: legend_utils
       pie_utils: pie_utils
+      text_section: text_section
       map_counties: map_counties
       map: build_map
-      directions_text: directions_text
       state_boundaries: state_boundaries_topojson
       county_boundaries: county_boundaries_topojson
       county_centroids_wu: county_centroids_wu_topojson
@@ -295,19 +302,4 @@ publish:
       resources: ["lib_d3_js", "topojson", 
                   "map_css", "custom_css", "hashes", "projection", "map_utils", 
                   "map_counties", "legend_utils", "pie_utils"]
-      embed: ["map","directions_text"]
-  -
-    id: description_text
-    template: printall
-    publisher: section
-    depends: description_text_md
-    context:
-      text: description_text_md.description_text-markdown
-  -
-    id: directions_text
-    template: printall
-    publisher: section
-    depends: description_text_md
-    context:
-      text: description_text_md.directions_text-markdown
-
+      embed: ["map", "text_section"]


### PR DESCRIPTION
This is how we added text in the Hurrican Marie Viz, https://github.com/USGS-VIZLAB/hurricane-maria/blob/master/viz.yaml so I copied that style. 

I believe this is how we are supposed to do it in the current version of Vizlab, as I don't feel great about messing with the printall publisher directly.  If you feel its a better decision let me know and we can discuss.

Vizlab will have a PR https://github.com/USGS-VIZLAB/vizlab/pull/362 adding the .viz-text class, which creates a basis for all the text going on into the future.

![screen shot 2018-03-23 at 1 10 28 pm](https://user-images.githubusercontent.com/6390096/37846433-9a72e34c-2e9b-11e8-8265-490f423ca1f6.png)
