### PR TITLE
County hovers + no circle sort = better category switch performance

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -102,6 +102,10 @@ function create_map() {
   
   // add the main, active map features
   addStates(map, stateData);
+  
+  // add placeholder group for county boundaries
+  map.append('g').classed("county-bounds", true);
+  
   if(activeCategory === 'piechart') {
     // prepare and then use the centroid data for presentation as pie charts
     pieFormData = pieData(countyCentroids);
@@ -112,12 +116,9 @@ function create_map() {
     pieFormData = pieData(countyCentroids);
   }
   
-  // get started downloading county data right away.
-  // for now, pretend that we know that state '01' is the most likely state
-  // for the user to click on; we could make this dynamic in the future.
-  loadCountyData("AL", function(error, data) {
-    if (error) throw error;
-  });
+  // load all county data - it's OK if it's not done right away
+  // it should be loaded by the time anyone tries to hover!
+  showCounties('USA');
 
 }
 

--- a/js/counties.js
+++ b/js/counties.js
@@ -12,7 +12,6 @@ function hideCountyLines() {
 
 function showCountyLines(state) {
   d3.selectAll('.county')
-    .filter(function(d) { return d.properties.STATE_ABBV === activeView; })
     .classed('hidden-border', false);
 }
 

--- a/js/counties.js
+++ b/js/counties.js
@@ -19,11 +19,11 @@ function loadCountyData(state, callback) {
   // for now let's always load the county data all at once. later we can again split
   // into single-state files if that turns out to be useful for performance.
   if(!countyData.has('USA')) {
-    d3.json("data/county_boundaries_USA.json", function(error, allCountiesTopo) {
+    d3.json("data/county_boundaries_wu.json", function(error, allCountiesTopo) {
       if(error) callback(error);
       
       // extract the topojson to geojson
-      allCountiesGeo = topojson.feature(allCountiesTopo, allCountiesTopo.objects.counties);
+      allCountiesGeo = topojson.feature(allCountiesTopo, allCountiesTopo.objects.foo);
       
       // cache in countyData
       countyData.set('USA', allCountiesGeo);

--- a/js/counties.js
+++ b/js/counties.js
@@ -23,7 +23,7 @@ function loadCountyData(state, callback) {
       if(error) callback(error);
       
       // extract the topojson to geojson
-      allCountiesGeo = topojson.feature(allCountiesTopo, allCountiesTopo.objects.foo);
+      allCountiesGeo = topojson.feature(allCountiesTopo, allCountiesTopo.objects.foo).features;
       
       // cache in countyData
       countyData.set('USA', allCountiesGeo);
@@ -44,7 +44,7 @@ function cacheCountyData(state, callback) {
   // state-caching approach could be useful in near future
   if(!countyData.has(state)) {
     // subset the data and run the processing function
-    oneStateCounties = countyData.get('USA').features.filter(function(d) {
+    oneStateCounties = countyData.get('USA').filter(function(d) {
       return(d.properties.STATE_ABBV === state);
     });
     countyData.set(state, oneStateCounties);
@@ -68,7 +68,8 @@ function displayCountyData(error, activeCountyData) {
     if(error) throw error;
     
     // create paths
-    var countyBounds = map.selectAll(".county")
+    var countyBounds = map.select('.county-bounds')
+      .selectAll(".county")
       .data(activeCountyData, function(d) {
         return d.properties.GEOID;
       });

--- a/js/counties.js
+++ b/js/counties.js
@@ -5,6 +5,17 @@ function hideCounties() {
     .remove();
 }
 
+function hideCountyLines() {
+  d3.selectAll('.county')
+    .classed('hidden-border', true);
+}
+
+function showCountyLines(state) {
+  d3.selectAll('.county')
+    .filter(function(d) { return d.properties.STATE_ABBV === activeView; })
+    .classed('hidden-border', false);
+}
+
 // call a series of functions to 
 // make sure we have the USA data and then
 // make sure we have this state stored in countyData and then
@@ -84,12 +95,10 @@ function displayCountyData(error, activeCountyData) {
       .enter()
       .append("path")
       .classed('county', true)
+      .classed('hidden-border', true) // add county shapes, but don't outline
       .attr('id', function(d) {
         return d.properties.GEOID;
       })
-      .style("fill", 'transparent') // none made it so you have to mouseover the boundary
-      .style("stroke", 'darkgrey')
-      .style("stroke-width", 0.2)
       .attr('d', buildPath)
       .on("mouseover", function(d) {
         highlightState(d3.select("#"+d.properties.STATE_ABBV));

--- a/js/counties.js
+++ b/js/counties.js
@@ -92,12 +92,14 @@ function displayCountyData(error, activeCountyData) {
       .attr('d', buildPath)
       .on("mouseover", function(d) {
         highlightCounty(this); 
+        highlightCircle(d3.select("#"+"circle-"+d.properties.GEOID));
+        showToolTip(d, activeCategory); 
         // OK to use global var activeCategory which only changes on click 
         // because people won't be able to hover on tooltips at the same time as hovering buttons
-        showToolTip(d, activeCategory); 
       })
       .on("mouseout", function(d) { 
-        unhighlightCounty(this); 
+        unhighlightCounty(this);
+        unhighlightCircle();
         hideToolTip();
       });
     

--- a/js/counties.js
+++ b/js/counties.js
@@ -104,7 +104,8 @@ function displayCountyData(error, activeCountyData) {
         unhighlightCounty(this);
         unhighlightCircle();
         hideToolTip();
-      });
+      })
+      .on('click', zoomToFromState);
     
     // update
     countyBounds

--- a/js/counties.js
+++ b/js/counties.js
@@ -92,6 +92,7 @@ function displayCountyData(error, activeCountyData) {
       .style("stroke-width", 0.2)
       .attr('d', buildPath)
       .on("mouseover", function(d) {
+        highlightState(d3.select("#"+d.properties.STATE_ABBV));
         highlightCounty(this); 
         highlightCircle(d3.select("#"+"circle-"+d.properties.GEOID));
         showToolTip(d, activeCategory); 
@@ -99,6 +100,7 @@ function displayCountyData(error, activeCountyData) {
         // because people won't be able to hover on tooltips at the same time as hovering buttons
       })
       .on("mouseout", function(d) { 
+        unhighlightState(d3.select("#"+d.properties.STATE_ABBV));
         unhighlightCounty(this);
         unhighlightCircle();
         hideToolTip();

--- a/js/counties.js
+++ b/js/counties.js
@@ -86,10 +86,16 @@ function displayCountyData(error, activeCountyData) {
       .attr('id', function(d) {
         return d.properties.GEOID;
       })
-      .style("fill", 'none')
+      .style("fill", 'transparent') // none made it so you have to mouseover the boundary
       .style("stroke", 'darkgrey')
       .style("stroke-width", 0.2)
-      .attr('d', buildPath);
+      .attr('d', buildPath)
+      .on("mouseover", function(d) {
+        highlightCounty(this); 
+      })
+      .on("mouseout", function(d) { 
+        unhighlightCounty(this); 
+      });
     
     // update
     countyBounds

--- a/js/counties.js
+++ b/js/counties.js
@@ -92,9 +92,13 @@ function displayCountyData(error, activeCountyData) {
       .attr('d', buildPath)
       .on("mouseover", function(d) {
         highlightCounty(this); 
+        // OK to use global var activeCategory which only changes on click 
+        // because people won't be able to hover on tooltips at the same time as hovering buttons
+        showToolTip(this, d, activeCategory); 
       })
       .on("mouseout", function(d) { 
         unhighlightCounty(this); 
+        hideToolTip(this, d, activeCategory);
       });
     
     // update

--- a/js/counties.js
+++ b/js/counties.js
@@ -94,11 +94,11 @@ function displayCountyData(error, activeCountyData) {
         highlightCounty(this); 
         // OK to use global var activeCategory which only changes on click 
         // because people won't be able to hover on tooltips at the same time as hovering buttons
-        showToolTip(this, d, activeCategory); 
+        showToolTip(d, activeCategory); 
       })
       .on("mouseout", function(d) { 
         unhighlightCounty(this); 
-        hideToolTip(this, d, activeCategory);
+        hideToolTip();
       });
     
     // update

--- a/js/counties.js
+++ b/js/counties.js
@@ -1,9 +1,3 @@
-function hideCounties() {
-  map.selectAll('.county')
-    //.data([])
-    //.exit()
-    .remove();
-}
 
 function hideCountyLines() {
   d3.selectAll('.county')

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -153,14 +153,12 @@ function unhighlightState() {
 
 // on mouseover
 function highlightCounty(selection) {
-  console.log("highlighting");
   d3.select(selection)
     .style('fill', function(d) { return "darkgrey"; });
 }
 
 // on mouseout
 function unhighlightCounty(selection) {
-  console.log("unhighlighting");
   d3.select(selection)
     .style("fill", function(d) { return "transparent" });
 }

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -53,7 +53,7 @@ function addCircles() {
     // this is OK to not worry about it changing on hover (activeCategory only changes on click) 
     // because people won't be able to see tooltips at the same time anyways
     .on("mouseover", function(d) { 
-      highlightCircle(this);
+      highlightCircle(d3.select(this));
       showToolTip(d, activeCategory); 
     })
     .on("mouseout", function(d) { 
@@ -304,7 +304,7 @@ function updateTitle(category) {
 }
 
 function highlightCircle(currentCircle) {
-  var orig = d3.select(currentCircle),
+  var orig = currentCircle,
       origNode = orig.node();
   var duplicate = d3.select(origNode.parentNode.appendChild(origNode.cloneNode(true), 
                                                             origNode.nextSibling));

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -50,16 +50,6 @@ function addCircles() {
     })
     .attr("cy", function(d) { 
       return projectY(d.geometry.coordinates);
-    })
-    // this is OK to not worry about it changing on hover (activeCategory only changes on click) 
-    // because people won't be able to see tooltips at the same time anyways
-    .on("mouseover", function(d) { 
-      highlightCircle(d3.select(this));
-      showToolTip(d, activeCategory); 
-    })
-    .on("mouseout", function(d) { 
-      unhighlightCircle();
-      hideToolTip(); 
     });
     
   circlesAdded = true;
@@ -107,10 +97,7 @@ function addStates(map, stateData) {
     .attr('d', buildPath)
     .style("fill", function(d) { return formatState('fill', d, false); })
     .style("stroke", function(d) { return formatState('stroke', d, false); })
-    .style("stroke-width", function(d) { return formatState('stroke-width', d, false); })
-    .on('mouseover', function(d) { return highlightState(d3.select(this)); })
-    .on('mouseout', function(d) { return unhighlightState(d3.select(this)); })
-    .on('click', zoomToFromState);
+    .style("stroke-width", function(d) { return formatState('stroke-width', d, false); });
 
   var nationBounds = buildPath.bounds(stateData);
   nationDims = {

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -66,9 +66,6 @@ function updateCircles(category) {
   }
 
   d3.selectAll(".county-point")
-    .sort(function(a,b) { 
-      return d3.descending(a.properties[[category]], b.properties[[category]]);
-    })
     //.transition().duration(0)
     .attr("r", function(d) {
       return scaleCircles(d.properties[[category]]);

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -52,8 +52,14 @@ function addCircles() {
     })
     // this is OK to not worry about it changing on hover (activeCategory only changes on click) 
     // because people won't be able to see tooltips at the same time anyways
-    .on("mouseover", function(d) { showToolTip(this, d, activeCategory); })
-    .on("mouseout", function(d) { hideToolTip(this, d); });
+    .on("mouseover", function(d) { 
+      highlightCircle(this);
+      showToolTip(d, activeCategory); 
+    })
+    .on("mouseout", function(d) { 
+      unhighlightCircle();
+      hideToolTip(); 
+    });
     
   circlesAdded = true;
   
@@ -297,18 +303,26 @@ function updateTitle(category) {
     .text("Water Use Data for " + activeView + ", 2015, " + category);
 }
 
-function showToolTip(currentCircle, d, category) {
+function highlightCircle(currentCircle) {
   var orig = d3.select(currentCircle),
       origNode = orig.node();
   var duplicate = d3.select(origNode.parentNode.appendChild(origNode.cloneNode(true), 
                                                             origNode.nextSibling));
-  
+                                                            
   // style duplicated circles sitting on top
   duplicate
     .classed('county-point-duplicate', true)
     .style("pointer-events", "none")
     .style("opacity", 1); // makes the duplicate circle on the top
-  
+}
+
+function unhighlightCircle() {
+  d3.select('.county-point-duplicate')
+    .remove(); // delete duplicate
+}
+
+function showToolTip(d, category) {
+
   // change tooltip
   d3.select(".tooltip")
     .classed("shown", true)
@@ -322,9 +336,7 @@ function showToolTip(currentCircle, d, category) {
               d.properties[[category]] + " " + "MGD");
 }
 
-function hideToolTip(currentCircle, d) {
-  d3.select('.county-point-duplicate')
-    .remove(); // delete duplicate
+function hideToolTip() {
   d3.select(".tooltip")
     .classed("shown", false)
     .classed("hidden", true);

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -238,7 +238,7 @@ function updateView(newView) {
   // d.properties.STATE_ABBV === activeView), but that didn't work with transitions.
   var states = map.selectAll('.state');
   if(activeView === 'USA') {
-    //hideCounties();
+    hideCountyLines();
     states
       .transition()
       .duration(750)
@@ -246,7 +246,7 @@ function updateView(newView) {
       .style("stroke", function(d) { return formatState('stroke', d, false); })
       .style("stroke-width", function(d) { return formatState('stroke-width', d, false); });
   } else {
-    //showCounties(activeView);
+    showCountyLines(activeView);
     states
       .transition()
       .duration(750)

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -151,6 +151,20 @@ function unhighlightState() {
     .style('stroke-width', function(d) { return formatState('stroke-width', d, false); });
 }
 
+// on mouseover
+function highlightCounty(selection) {
+  console.log("highlighting");
+  d3.select(selection)
+    .style('fill', function(d) { return "darkgrey"; });
+}
+
+// on mouseout
+function unhighlightCounty(selection) {
+  console.log("unhighlighting");
+  d3.select(selection)
+    .style("fill", function(d) { return "transparent" });
+}
+
 // on click
 function zoomToFromState(data) {
 

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -108,8 +108,8 @@ function addStates(map, stateData) {
     .style("fill", function(d) { return formatState('fill', d, false); })
     .style("stroke", function(d) { return formatState('stroke', d, false); })
     .style("stroke-width", function(d) { return formatState('stroke-width', d, false); })
-    .on('mouseover', highlightState)
-    .on('mouseout', unhighlightState)
+    .on('mouseover', function(d) { return highlightState(d3.select(this)); })
+    .on('mouseout', function(d) { return unhighlightState(d3.select(this)); })
     .on('click', zoomToFromState);
 
   var nationBounds = buildPath.bounds(stateData);
@@ -143,16 +143,16 @@ formatState = function(attr, d, active) {
 }
 
 // on mouseover
-function highlightState() {
-  d3.select(this)
+function highlightState(selection) {
+  selection
     .style('fill', function(d) { return formatState('fill', d, true); })
     .style('stroke', function(d) { return formatState('stroke', d, true); })
     .style('stroke-width', function(d) { return formatState('stroke-width', d, true); });
 }
 
 // on mouseout
-function unhighlightState() {
-  d3.select(this)
+function unhighlightState(selection) {
+  selection
     .style("fill", function(d) { return formatState('fill', d, false); })
     .style('stroke', function(d) { return formatState('stroke', d, false); })
     .style('stroke-width', function(d) { return formatState('stroke-width', d, false); });

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -159,8 +159,13 @@ function zoomToFromState(data) {
 
   // get the ID of the state that was clicked on (or NULL if it's not an ID).
   // could also use clickedState to set the URL, later
-  clickedView = data.properties.STATE_ABBV;
-
+  clickedView = d3.select(this).attr('id'); // need this in order to use background
+  
+  if( clickedView != 'map-background' ) {
+    // id of selection is a county code, but need to extract the state abbreviation from it
+    var clickedView = d3.select(this).data()[0].properties.STATE_ABBV;
+  }
+  
   // determine the new view
   if(clickedView === 'map-background' || activeView != 'USA') {
     // could have made it so we go national only if they click on the background

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -42,6 +42,7 @@ function addCircles() {
     .enter()
     .append('circle')
     .classed('county-point', true)
+    .attr("id", function(d) { return "circle-"+d.properties.GEOID; })
     .attr("cx", function(d) {
       var coordx = projectX(d.geometry.coordinates);
       if(coordx === 0) { console.log(d); } // moved outside of project function bc coordinates aren't always d.geometry.coordinates (like in pies)

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -53,7 +53,7 @@ function addCircles() {
     // this is OK to not worry about it changing on hover (activeCategory only changes on click) 
     // because people won't be able to see tooltips at the same time anyways
     .on("mouseover", function(d) { showToolTip(this, d, activeCategory); })
-    .on("mouseout", function(d) { hideTooltip(this, d); });
+    .on("mouseout", function(d) { hideToolTip(this, d); });
     
   circlesAdded = true;
   
@@ -324,7 +324,7 @@ function showToolTip(currentCircle, d, category) {
               d.properties[[category]] + " " + "MGD");
 }
 
-function hideTooltip(currentCircle, d) {
+function hideToolTip(currentCircle, d) {
   d3.select('.county-point-duplicate')
     .remove(); // delete duplicate
   d3.select(".tooltip")

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -175,7 +175,7 @@ function zoomToFromState(data) {
 
   // get the ID of the state that was clicked on (or NULL if it's not an ID).
   // could also use clickedState to set the URL, later
-  clickedView = d3.select(this).attr('id'); // should be same as data.properties.STATE_ABBV;
+  clickedView = data.properties.STATE_ABBV;
 
   // determine the new view
   if(clickedView === 'map-background' || activeView != 'USA') {
@@ -238,7 +238,7 @@ function updateView(newView) {
   // d.properties.STATE_ABBV === activeView), but that didn't work with transitions.
   var states = map.selectAll('.state');
   if(activeView === 'USA') {
-    hideCounties();
+    //hideCounties();
     states
       .transition()
       .duration(750)
@@ -246,7 +246,7 @@ function updateView(newView) {
       .style("stroke", function(d) { return formatState('stroke', d, false); })
       .style("stroke-width", function(d) { return formatState('stroke-width', d, false); });
   } else {
-    showCounties(activeView);
+    //showCounties(activeView);
     states
       .transition()
       .duration(750)

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -13,6 +13,17 @@
   stroke-linecap: round;
 }
 
+.county {
+  fill: transparent;
+  stroke: darkgrey;
+  stroke-width: 0.2;
+}
+
+.hidden-border {
+  stroke: transparent;
+  stroke-width: 0;
+}
+
 #slideraxis path,
 #slideraxis line {
   stroke: #fff;

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -24,6 +24,11 @@
   stroke-width: 0;
 }
 
+.county-point,
+.pieslice {
+  pointer-events: none;
+}
+
 #slideraxis path,
 #slideraxis line {
   stroke: #fff;

--- a/scripts/process/merge_centroids_wu.R
+++ b/scripts/process/merge_centroids_wu.R
@@ -1,17 +1,17 @@
 process.merge_centroids_wu <- function(viz) {
   deps <- readDepends(viz)
   wu_data_15_simple <- deps[["wu_data_15_simple"]]
-  centroids_topo <- geojsonio::topojson_read(as.viz(viz$depends$centroids_topo)$location, stringsAsFactors=FALSE) # bypass readDepends for topojson
+  topo <- geojsonio::topojson_read(as.viz(viz$depends$topo)$location, stringsAsFactors=FALSE) # bypass readDepends for topojson
   
   # merge datasets and keep a minimal set of columns
-  centroids_data <- centroids_topo@data %>%
+  county_data <- topo@data %>%
     left_join(wu_data_15_simple, by=c('GEOID'='FIPS')) %>%
     select(GEOID, STATE_ABBV, COUNTY, countypop:industrial) %>% 
     rowwise() %>% 
     mutate(other = total - sum(thermoelectric, publicsupply, irrigation, industrial))
   
-  centroids_topo@data <- centroids_data
+  topo@data <- county_data
   
   # write to file
-  geojsonio::topojson_write(centroids_topo, file=viz[['location']])
+  geojsonio::topojson_write(topo, file=viz[['location']])
 }

--- a/viz.yaml
+++ b/viz.yaml
@@ -156,7 +156,16 @@ process:
     location: cache/county_centroids_wu.json
     mimetype: application/json
     depends:
-      centroids_topo: county_centroids_topojson
+      topo: county_centroids_topojson
+      wu_data_15_simple: wu_data_15_simple
+    processor: merge_centroids_wu
+    scripts: [scripts/process/merge_centroids_wu.R]
+  -
+    id: county_boundaries_wu_topojson
+    location: cache/county_boundaries_wu.json
+    mimetype: application/json
+    depends:
+      topo: county_boundaries_topojson
       wu_data_15_simple: wu_data_15_simple
     processor: merge_centroids_wu
     scripts: [scripts/process/merge_centroids_wu.R]
@@ -191,7 +200,7 @@ publish:
       map_counties: "map_counties"
       map: "build_map"
       state_boundaries: "state_boundaries_topojson"
-      county_boundaries: "county_boundaries_topojson"
+      county_boundaries_wu: "county_boundaries_wu_topojson"
       county_centroids_wu: "county_centroids_wu_topojson"
       wu_data_15_range:  "wu_data_15_range_json"
     context:
@@ -288,7 +297,7 @@ publish:
       map: build_map
       directions_text: directions_text
       state_boundaries: state_boundaries_topojson
-      county_boundaries: county_boundaries_topojson
+      county_boundaries_wu: county_boundaries_wu_topojson
       county_centroids_wu: county_centroids_wu_topojson
       wu_data_15_range:  wu_data_15_range_json
     context:


### PR DESCRIPTION
Now all mouseovers and clicks are based on the county polygons, which are loaded from the start. Circles highlight when the county is hovered over, but they actually don't have pointer events on. Colors for states, counties, and highlights need work. You can also see all county boundaries when zoomed in. It currently displays all of them, but we can work on trying a clip to show which counties are in view and which aren't. This was already a lot of change and I didn't want to go too crazy. I think having all the counties on zoom helps with the cutoff circles a little bit. 

![countyhovers](https://user-images.githubusercontent.com/13220910/38140765-d2c32018-33fa-11e8-807d-a3910b316b90.gif)

Category switching is much faster now that we turned off sorting. Unfortunately, the full load time for the page has increased because all counties are loading at the national view. The time to be able to see circles on the map is slightly quicker than before (because no sorting is needed), but there's just a slight lag before you can start hovering on counties.

Performance results:

## Page load times

### BEFORE: Load times to `view=USA&category=total` (milliseconds):

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'load' handler took __ms
-- | -- | -- | -- | --
1990 | 1178 | 44 | 8 | --
1991 | 1193 | 44 | 8 | --
1173 | 970 | 42 | 5 | --
2039 | 1231 | 45 | 9 | --
1196 | 994 | 37 | 5 | --

### AFTER: Load times to finish loading everything (so the county polygons)

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'load' handler took __ms
-- | -- | -- | -- | --
2446 | 1969 | 84 | 8 | --
2467 | 2056 | 70 | 8 | --
2541 | 2060 | 104 | 12 | --
2492 | 2084 | 77 | 8 | --
2797 | 2369 | 74 | 9 | --

### AFTER: Load times to see the map w/ circles

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'load' handler took __ms
-- | -- | -- | -- | --
1037 | 899 | 46 | 5 | --
1129 | 882 | 36 | 5 | --
1217 | 950 | 41 | 8 | --
1181 | 928 | 41 | 5 | --
1200 | 925 | 40 | 6 | --

## Times for first transition from Total to Pie view
As expected, these didn't really change much since the sorting was happening within the regular circles and I don't think that affected pies.

### BEFORE

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'mouseover' handler
-- | -- | -- | -- | --
-- | 291 | 216 | 23 | 291
-- | 366 | 200 | 24 | 294
-- | 402 | 228 | 26 | 258
-- | 358 | 218 | 26 | 308
-- | 357 | 196 | 24 | 279

### AFTER

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'mouseover' handler
-- | -- | -- | -- | --
-- | 364 | 195 | 25 | 332
-- | 319 | 200 | 27 | 260
-- | 377 | 200 | 28 | 317
-- | 476 | 210 | 27 | 442
-- | 354 | 197 | 26 | 321

## Times for subsequent transitions from Total to Pie view
As expected, these didn't really change much since the sorting was happening within the regular circles and I don't think that affected pies.

### BEFORE

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'mouseover' handler
-- | -- | -- | -- | --
-- | 211 | 165 | 23 | 129
-- | 131 | 169 | 26 | 131
-- | 139 | 171 | 24 | 139
-- | 161 | 179 | 27 | 161
-- | 136 | 166 | 22 | 136

### AFTER

total | scripts (all the yellow) | rendering (all the purple) | painting (all the green) | 'mouseover' handler
-- | -- | -- | -- | --
-- | 149 | 169 | 24 | 149
-- | 136 | 166 | 25 | 134
-- | 144 | 177 | 33 | 144
-- | 134 | 178 | 26 | 131
-- | 148 | 199 | 30 | 146

## Times for transitions among circle categories (mouseovers)

### BEFORE

total | scripts (yellow) | rendering (purple) | painting (green) | 'mouseover' handler | from what to what
-- | -- | -- | -- | -- | --
-- | 126 | 24 | 4 | 112 | from blue to blue!
-- | 57 | 34 | 2 | 56 | blue to yellow
-- | 88 | 42 | 6 | 86 | blue to red
-- | 73 | 30 | 5 | 72 | blue to green
-- | 60 | 35 | 4 | 60 | blue to grey

### AFTER

total | scripts (yellow) | rendering (purple) | painting (green) | 'mouseover' handler | from what to what
-- | -- | -- | -- | -- | --
-- | 23 | 20 | 6 | 22 | from blue to blue!
-- | 25 | 29 | 3 | 23 | blue to yellow
-- | 27 | 35 | 4 | 25 | blue to red
-- | 25 | 33 | 5 | 24 | blue to green
-- | 24 | 30 | 3 | 24 | blue to grey

## Times for transitions among circle categories (mouseouts)

### BEFORE

total | scripts (yellow) | rendering (purple) | painting (green) | 'mouseout' handler | from what to what
-- | -- | -- | -- | -- | --
-- | 70 | 26 | 4 | 70 | blue to blue
-- | 102 | 40 | 5 | 102 | yellow to blue
-- | 107 | 33 | 4 | 100 | red to blue
-- | 86 | 34 | 4 | 85 | green to blue
-- | 87 | 32 | 4 | 86 | grey to blue

### AFTER

total | scripts (yellow) | rendering (purple) | painting (green) | 'mouseout' handler | from what to what
-- | -- | -- | -- | -- | --
-- | 15 | 21 | 5 | 14 | blue to blue
-- | 23 | 51 | 24 | 22 | yellow to blue
-- | 17 | 33 | 4 | 16 | red to blue
-- | 23 | 30 | 4 | 23 | green to blue
-- | 23 | 47 | 4 | 22 | grey to blue