### PR TITLE
county bounds goof

### DIFF
--- a/js/styles.js
+++ b/js/styles.js
@@ -55,7 +55,7 @@ function backgroundState(selection, scale) {
 // on zoom out
 
 function hideCountyLines() {
-  d3.selectAll('.show-county-county')
+  d3.selectAll('.show-county-bounds')
     .classed("show-county-bounds", false); 
 }
 


### PR DESCRIPTION
A typo from #172 led to county bound outlines hanging around after you zoom out. Fixed.