### PR TITLE
parts of #135

### DIFF
--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -134,12 +134,14 @@ function updateView(newView, fireAnalytics) {
     backgroundState(otherstates, scale = zoom_scale);
     foregroundState(thisstate, scale = zoom_scale);
     
-    statecounties
-      .transition()
-      .duration(500) 
-      .style("stroke-width",  0.75/zoom_scale); // make all counties have scaled stroke-width
+    
   }
-
+  var allcounties = d3.selectAll('.county');
+  
+  allcounties.transition()
+    .duration(500) 
+    .style("stroke-width",  1/zoom_scale); // make all counties have scaled stroke-width
+  
   // apply the transform (i.e., actually zoom in or out)
   map.transition()
     .duration(750)

--- a/js/styles.js
+++ b/js/styles.js
@@ -10,7 +10,7 @@ function categoryToName(category) {
 }
 
 function categoryToColor(category) {
-  if (category === "total") { return "rgba(38, 120, 178, 0.8)"; }
+  if (category === "total") { return "rgba(38, 140, 178, 0.8)"; }
   else if (category === "thermoelectric") { return "rgba(237, 201, 72, 0.8)"; }
   else if (category === "publicsupply") { return "rgba(118, 183, 178, 0.8)"; }
   else if (category === "irrigation") { return "rgba(89, 161, 79, 0.8)"; }
@@ -38,7 +38,7 @@ function foregroundState(selection, scale) {
   selection
     .transition()
     .duration(500)
-    .style("stroke-width",  2.5/scale); // scale stroke-width
+    .style("stroke-width",  2/scale); // scale stroke-width
 }
 
 function backgroundState(selection, scale) {
@@ -49,7 +49,7 @@ function backgroundState(selection, scale) {
   selection
     .transition()
     .duration(500)
-    .style("stroke-width",  0.75/scale); // scale stroke-width;
+    .style("stroke-width",  1/scale); // scale stroke-width;
 }
 
 // on zoom out
@@ -68,7 +68,7 @@ function resetState() {
   d3.selectAll('.state')
     .transition()
     .duration(750)
-    .style("stroke-width", null); // use null to get back to CSS
+    .style("stroke-width", 1); // use null to get back to CSS
 }
 
 // on mouseover

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -5,8 +5,7 @@
 
 .state {
   fill: transparent;
-  stroke: black;
-  stroke-width: 1.5;
+  stroke: rgb(180,180,180);
   stroke-linejoin: round;
   stroke-linecap: round;
   pointer-events: none;
@@ -24,11 +23,13 @@
 /* must be listed before highlighted-county*/
 /* THIS IS WHAT WILL MAKE THE ZOOMED IN STATE EMPHASIZED*/
 .emphasize-county {
-  fill: #e3e3e3; /* light-ish grey */
+  fill: rgb(230,230,230);
+  stroke: rgb(200,200,200);
 }
 
 .highlighted-county {
-  fill: #bdbdbd; /* dark-ish grey */
+  stroke: rgb(200,200,200);
+  fill: rgb(240,240,240);
 } 
 
 .wu-circle {


### PR DESCRIPTION
from #135:
~map outlines and fills~
![image](https://user-images.githubusercontent.com/2349007/38619973-0196d30a-3d63-11e8-8317-8a7e7a213ffd.png)
vs
![image](https://user-images.githubusercontent.com/2349007/38619998-0ed537f0-3d63-11e8-9642-76e3fddea7ef.png)

~county boundaries for non-active state look exaggerated when scaling~

~main blue color for total is too purple and we want to get this color right, since it is the one that everyone will see~
is now:
![image](https://user-images.githubusercontent.com/2349007/38620049-2c16cc70-3d63-11e8-9e63-1ba7f5cb4f08.png)

I also changed the county mouseover style at the national level:
![image](https://user-images.githubusercontent.com/2349007/38620124-534ec086-3d63-11e8-865d-bcd7e03927cb.png)
vs
![image](https://user-images.githubusercontent.com/2349007/38620142-5edcd776-3d63-11e8-9504-482551702dc6.png)
and when zoomed in