### PR TITLE
Mobile click

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -159,7 +159,6 @@ function fillMap() {
   updateCircles(activeCategory);
   
   // manipulate dropdowns
-  // need to figure out how to do this for only mobile views
   updateViewSelectorOptions(activeView, stateBoundsUSA);
   addZoomOutButton(activeView);
   

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -160,7 +160,7 @@ function fillMap() {
   
   // manipulate dropdowns
   // need to figure out how to do this for only mobile views
-  updateViewSelectorOptions(activeView, stateBoundsUSA, countyCentroids);
+  updateViewSelectorOptions(activeView, stateBoundsUSA);
   addZoomOutButton(activeView);
   
   // load county data, add and update county polygons.

--- a/js/counties.js
+++ b/js/counties.js
@@ -119,7 +119,31 @@ function displayCountyBounds(error, activeCountyData) {
         unhighlightCircle();
         hideToolTip();
       })
-      .on('click', zoomToFromState);
+      .on('click', function(d) {
+        
+        // clicking a county on mobile has no affect on the 
+        // view unless it's the same county as last time
+        if(waterUseViz.mode === "mobile") {
+          
+          var prevCounty = waterUseViz.prevClickCounty;
+          var thisCountyID = d3.select(this).attr("id");
+          if(prevCounty === thisCountyID) {
+            
+            //only zoom out if you click on the same county 
+            zoomToFromState(d, d3.select(this));
+            
+            // hide on any zoom bc no county will be selected
+            unhighlightCounty();
+            unhighlightCircle();
+            hideToolTip(); 
+          }
+          // set prevClickCounty as global var for next click
+          waterUseViz.prevClickCounty = thisCountyID;
+        } else {
+          // desktop county clicks zoom in and out
+          zoomToFromState(d, d3.select(this));
+        }
+      });
     
     // update
     countyBounds

--- a/js/counties.js
+++ b/js/counties.js
@@ -110,7 +110,7 @@ function displayCountyBounds(error, activeCountyData) {
       .on("mouseover", function(d) {
         highlightCounty(d3.select(this)); 
         highlightCircle(d.properties, activeCategory);
-        showToolTip(d, activeCategory); 
+        showToolTip(d.properties, activeCategory); 
         // OK to use global var activeCategory which only changes on click 
         // because people won't be able to hover on tooltips at the same time as hovering buttons
       })
@@ -136,7 +136,9 @@ function displayCountyBounds(error, activeCountyData) {
             unhighlightCounty();
             unhighlightCircle();
             hideToolTip(); 
-          }
+          } else {
+            updateCountySelector(thisCountyID);
+          }          
           // set prevClickCounty as global var for next click
           waterUseViz.prevClickCounty = thisCountyID;
         } else {

--- a/js/counties.js
+++ b/js/counties.js
@@ -119,7 +119,7 @@ function displayCountyBounds(error, activeCountyData) {
         unhighlightCircle();
         hideToolTip();
       })
-      .on('click', function(d) {
+      .on('click', function(d,i,j) {
         
         // clicking a county on mobile has no affect on the 
         // view unless it's the same county as last time
@@ -130,7 +130,7 @@ function displayCountyBounds(error, activeCountyData) {
           if(prevCounty === thisCountyID) {
             
             //only zoom out if you click on the same county 
-            zoomToFromState(d, d3.select(this));
+            zoomToFromState(d,i,j, d3.select(this));
             
             // hide on any zoom bc no county will be selected
             unhighlightCounty();
@@ -143,7 +143,7 @@ function displayCountyBounds(error, activeCountyData) {
           waterUseViz.prevClickCounty = thisCountyID;
         } else {
           // desktop county clicks zoom in and out
-          zoomToFromState(d, d3.select(this));
+          zoomToFromState(d,i,j, d3.select(this));
         }
       });
     

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -68,16 +68,20 @@ function updateViewSelectorOptions(view, stateBounds, countyCentroids) {
       .property("value", function(d) { return d.properties.STATE_ABBV; })
       .text(function(d) { return d.properties.STATE_NAME; });
         
-  // change default selection if view is different from USA on load
-  if(view !== "USA") {
-    viewOptions.property("selected", function(d){ 
-        return d.properties.STATE_ABBV === view; 
-      });
-  }
+  // make sure default selection matches view (esp if different from USA on load)
+  updateStateSelector(view);
   
   // needed here in case initial view is not 'USA'
   updateCountySelectorDropdown(view);
 
+}
+
+function updateStateSelector(view) {
+  d3.select(".view-select")
+    .selectAll("option")
+    .property("selected", function(d) {
+      return d.properties.STATE_ABBV === view; 
+    });
 }
 
 function updateCountySelectorOptions(countyData) {
@@ -134,12 +138,8 @@ function updateCountySelectorOptions(countyData) {
     .insert("option", ":first-child")
       .property("value", "Select County")
       .text("--Select County--");
-      
-  countyMenu.selectAll("option")
-    .property("selected", function(d,i) {
-      // select county was just inserted into the first spot (so index 0) above
-      return i === 0; 
-    });
+  resetCountySelector();
+  
 }
 
 function updateCountySelectorDropdown(view) {
@@ -151,4 +151,14 @@ function updateCountySelectorDropdown(view) {
   } else {
     countySelectorDiv.classed("hidden", false);
   }
+}
+
+function resetCountySelector() {
+  d3.select("body")
+    .select(".county-select")
+    .selectAll("option")
+      .property("selected", function(d,i) {
+        // select county was just inserted into the first spot (so index 0) above
+        return i === 0; 
+      });
 }

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -106,7 +106,7 @@ function addCountyOptions(selectedView) {
 }
 
 function updateCountySelectorOptions(countyData) {
-  console.log("counties added");
+  
   var countyMenu = d3.select("body")
         .select(".county-select")
         .attr("id", "county-menu")
@@ -132,8 +132,6 @@ function updateCountySelectorOptions(countyData) {
             // set prevClickCounty as global var for next click
             waterUseViz.prevClickCounty = thisCountyGEOID;
           }
-          
-          console.log("this will also update the data in the category legend");
         });
         
   // alphabetize counties

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -96,7 +96,7 @@ function addCountyOptions(selectedView) {
 }
 
 function updateCountySelectorOptions(countyData) {
-  
+  console.log("counties added");
   var countyMenu = d3.select("body")
         .select(".county-select")
         .attr("id", "county-menu")
@@ -105,18 +105,22 @@ function updateCountySelectorOptions(countyData) {
           // start by resetting what is highlighted
           unhighlightCounty();
           unhighlightCircle();
+          hideToolTip();
           
           var menu = document.getElementById("county-menu");
           var thisCountyGEOID = menu.options[menu.selectedIndex].value;
           
           if(thisCountyGEOID != "Select County") {
-            
             var thisCountySel = d3.selectAll('.county')
                   .filter(function(d) { return d.properties.GEOID === thisCountyGEOID; });
             var thisCountyData = countyData.filter(function(d) { return d.GEOID === thisCountyGEOID; })[0];
             
             highlightCounty(thisCountySel);
             highlightCircle(thisCountyData, activeCategory);
+            showToolTip(thisCountyData, activeCategory);
+            
+            // set prevClickCounty as global var for next click
+            waterUseViz.prevClickCounty = thisCountyGEOID;
           }
           
           console.log("this will also update the data in the category legend");
@@ -164,7 +168,22 @@ function updateCountySelectorDropdown(view) {
   }
 }
 
+function updateCountySelector(countyGeoid) {
+  
+  d3.select("body")
+    .select(".county-select")
+    .selectAll("option")
+      .property("selected", function(d,i) {
+        if(i === 0) { // skip over "--Select County--" because d is undefined
+          return false;
+        } else {
+          return d.GEOID === countyGeoid; 
+        }
+      });
+}
+
 function resetCountySelector() {
+    
   d3.select("body")
     .select(".county-select")
     .selectAll("option")

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -10,14 +10,6 @@ function addZoomOutButton(view) {
       
       // actually change the view
       updateView('USA');
-      
-      // change selector back to default
-      d3.select("body")
-        .select(".view-select")
-        .selectAll("option")
-        .property("selected", function(d){ 
-          return d.properties.STATE_ABBV === 'USA'; 
-        });
         
     });
   
@@ -85,8 +77,17 @@ function updateViewSelectorOptions(view, stateBounds) {
 function updateStateSelector(view) {
   d3.select(".view-select")
     .selectAll("option")
-    .property("selected", function(d) {
-      return d.properties.STATE_ABBV === view; 
+    .property("selected", function(d,i) {
+      if(view === 'USA') {
+        return i === 0; // USA option was inserted as first, so 0 index
+      } else {
+        // skip over "USA" because d is undefined
+        if(i === 0) { 
+          return false;
+        } else {
+          return d.properties.STATE_ABBV === view; 
+        }
+      }
     });
     
   // update the available options

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -81,7 +81,9 @@ function updateStateSelector(view) {
     });
     
   // update the available options
-  addCountyOptions(view);
+  if(view !== "USA") {
+    addCountyOptions(view);
+  }
 }
 
 function addCountyOptions(selectedView) {

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -37,7 +37,7 @@ function updateZoomOutButton(view) {
   }
 }
 
-function updateViewSelectorOptions(view, stateBounds, countyCentroids) {
+function updateViewSelectorOptions(view, stateBounds) {
   
   var viewMenu = d3.select("body")
         .select(".view-select")
@@ -53,10 +53,7 @@ function updateViewSelectorOptions(view, stateBounds, countyCentroids) {
           unhighlightCounty();
           unhighlightCircle();
           
-          // filter to correct county data then update dropdowns
-          var stateCountyData = countyCentroids
-            .filter(function(d) { return d.STATE_ABBV === selectedView; });
-          updateCountySelectorOptions(stateCountyData);
+          addCountyOptions(selectedView);
           
         });
   
@@ -82,6 +79,18 @@ function updateStateSelector(view) {
     .property("selected", function(d) {
       return d.properties.STATE_ABBV === view; 
     });
+    
+  // update the available options
+  addCountyOptions(view);
+}
+
+function addCountyOptions(selectedView) {
+  //uses global variable, `countyCentroids`
+  
+  // filter to correct county data then update dropdowns
+  var stateCountyData = countyCentroids
+    .filter(function(d) { return d.STATE_ABBV === selectedView; });
+  updateCountySelectorOptions(stateCountyData);
 }
 
 function updateCountySelectorOptions(countyData) {

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -57,12 +57,23 @@ function updateViewSelectorOptions(view, stateBounds) {
   
   // add states as options
   var viewOptions = viewMenu.selectAll("option")
-    .data(stateBounds.features) // ALABAMA IS CURRENTLY MISSING
+        .data(stateBounds.features);
+  
+  // add new options
+  viewOptions
     .enter()
-    .append("option")
-      .property("value", function(d) { return d.properties.STATE_ABBV; })
-      .text(function(d) { return d.properties.STATE_NAME; });
-        
+    .append("option");
+  
+  //update existing options with data (aka include the one that initially exists)
+  viewMenu.selectAll("option")
+    .property("value", function(d) { return d.properties.STATE_ABBV; })
+    .text(function(d) { return d.properties.STATE_NAME; });
+  
+  viewMenu
+    .insert("option", ":first-child")
+      .property("value", "USA")
+      .text("United States");
+     
   // make sure default selection matches view (esp if different from USA on load)
   updateStateSelector(view);
   

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -53,8 +53,6 @@ function updateViewSelectorOptions(view, stateBounds) {
           unhighlightCounty();
           unhighlightCircle();
           
-          addCountyOptions(selectedView);
-          
         });
   
   // add states as options
@@ -131,11 +129,16 @@ function updateCountySelectorOptions(countyData) {
   
   // bind data to options in county dropdown menu
   var countyOptions = countyMenu
-        .selectAll("option");
+        .selectAll("option")
+          .data(countyData);
+          
+  // remove old options
+  countyOptions
+    .exit()
+      .remove();
   
   // add new options
   countyOptions
-    .data(countyData)
     .enter()
     .append("option");
   
@@ -144,11 +147,6 @@ function updateCountySelectorOptions(countyData) {
     .property("value", function(d) { return d.GEOID; })
     .text(function(d) { return d.COUNTY; });
   
-  // remove old options
-  countyOptions
-    .exit()
-      .remove();
-      
   countyMenu
     .insert("option", ":first-child")
       .property("value", "Select County")

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -11,7 +11,6 @@ function addStates(map, stateBounds) {
   var clickClass = "state-click-off"; // default to desktop
   if(waterUseViz.mode === "mobile") {
     clickClass = "state-click-on";
-    console.log(waterUseViz.mode);
   }
   
   // add states
@@ -224,17 +223,17 @@ function showToolTip(d, category) {
     .style("left", (d3.event.pageX + 35) + "px")
     .style("top", (d3.event.pageY - 50) + "px");
   d3.select(".tooltip")
-    .html(d.properties.COUNTY + ", " + d.properties.STATE_ABBV + "<br/>" + 
-            "Population: " + d.properties.countypop + "<br/>" +
+    .html(d.COUNTY + ", " + d.STATE_ABBV + "<br/>" + 
+            "Population: " + d.countypop + "<br/>" +
             categoryToName(category) + ": " + 
-              d.properties[[category]] + " " + "MGD");
+              d[[category]] + " " + "MGD");
   if(toolTipTimer){
     clearTimeout(toolTipTimer);
   }
   toolTipTimer = setTimeout(function(){
      gtag('event', 'hover', {
   'event_category': 'figure',
-  'event_label': d.properties.COUNTY + ", " + d.properties.STATE_ABBV + '; category=' + category + '; view=' + activeView});
+  'event_label': d.COUNTY + ", " + d.STATE_ABBV + '; category=' + category + '; view=' + activeView});
   }, toolTipDelay);
 }
 

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -20,7 +20,8 @@ function addStates(map, stateBounds) {
     .attr('id', function(d) {
       return d.properties.STATE_ABBV;
     })
-    .attr('d', buildPath);
+    .attr('d', buildPath)
+    .on('click', zoomToFromState);
 
   var nationBounds = buildPath.bounds(stateBounds);
   nationDims = {

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -7,6 +7,13 @@ var zoom_scale;
 // Create the state polygons
 function addStates(map, stateBounds) {
 
+  // changes pointer events depending on mobile or desktop
+  var clickClass = "state-click-off"; // default to desktop
+  if(waterUseViz.mode === "mobile") {
+    clickClass = "state-click-on";
+    console.log(waterUseViz.mode);
+  }
+  
   // add states
   map.select('#state-bounds')
     .selectAll( 'path' )
@@ -16,7 +23,7 @@ function addStates(map, stateBounds) {
     .enter()
     .append('path')
     .classed('state', true)
-    .classed('state-'+waterUseViz.mode, true) // changes pointer events depending on mobile or desktop
+    .classed(clickClass, true)
     .attr('id', function(d) {
       return d.properties.STATE_ABBV;
     })

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -16,6 +16,7 @@ function addStates(map, stateBounds) {
     .enter()
     .append('path')
     .classed('state', true)
+    .classed('state-'+waterUseViz.mode, true) // changes pointer events depending on mobile or desktop
     .attr('id', function(d) {
       return d.properties.STATE_ABBV;
     })

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -64,11 +64,16 @@ function addStates(map, stateBounds) {
 }
 
 // on click
-function zoomToFromState(d, selection) {
+function zoomToFromState(d, i, j, selection) {
   
-  if(typeof selection === "number") { // because `i` is defaulted
-    // couldn't rely on this when I changed from `.on("click", zoomToFromState)`
-    // to `.on("click", function(d) { zoomToFromState(); })`
+    // In some cases use `.on("click", zoomToFromState)` which makes first two args
+    //  default to d (data), i (index), and j (parent data). If that's the case, we 
+    //  need to explicitly select `this` here.
+    // In other cases, we had to pass `d3.select(this)` in as an argument. I am not
+    //  quite sure why. But that's why the argument `selection` is added on. In those
+    //  cases, this function is called by `zoomToFromState(d,i,d3.select(this))`
+  
+  if(typeof selection === "undefined") {
     selection = d3.select(this);
   } 
   

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -45,15 +45,21 @@ function addStates(map, stateBounds) {
 }
 
 // on click
-function zoomToFromState(data) {
-
+function zoomToFromState(d, selection = null) {
+  
+  if(typeof selection === "number") { // because `i` is defaulted
+    // couldn't rely on this when I changed from `.on("click", zoomToFromState)`
+    // to `.on("click", function(d) { zoomToFromState(); })`
+    selection = d3.select(this);
+  } 
+  
   // get the ID of the state that was clicked on (or NULL if it's not an ID).
   // could also use clickedState to set the URL, later
-  var clickedView = d3.select(this).attr('id'); // need this in order to use background
+  var clickedView = selection.attr('id'); // need this in order to use background
   
   if( clickedView !== 'map-background' ) {
     // need to extract the state abbreviation from either county or state polygon
-    clickedView = d3.select(this).data()[0].properties.STATE_ABBV;
+    clickedView = selection.data()[0].properties.STATE_ABBV;
   }
   
   // determine the new view

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -44,7 +44,7 @@ function zoomToFromState(data) {
   var clickedView = d3.select(this).attr('id'); // need this in order to use background
   
   if( clickedView !== 'map-background' ) {
-    // id of selection is a county code, but need to extract the state abbreviation from it
+    // need to extract the state abbreviation from either county or state polygon
     clickedView = d3.select(this).data()[0].properties.STATE_ABBV;
   }
   
@@ -71,8 +71,13 @@ function updateView(newView, fireAnalytics) {
   oldView = activeView;
   activeView = newView;
   
+  // set hash and set category selectors (will see on mobile)
   setHash('view', activeView);
-
+  if(d3.select(".view-select").selectAll("option").data().length > 1) {
+    // only update the selector if they've been added already
+    updateStateSelector(activeView);
+  } 
+  
   // determine the center point and scaling for the new view
   var x, y;
   if(activeView === 'USA') {

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -64,7 +64,7 @@ function addStates(map, stateBounds) {
 }
 
 // on click
-function zoomToFromState(d, selection = null) {
+function zoomToFromState(d, selection) {
   
   if(typeof selection === "number") { // because `i` is defaulted
     // couldn't rely on this when I changed from `.on("click", zoomToFromState)`

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -159,6 +159,9 @@ function updateView(newView, fireAnalytics) {
   hideCountyLines();
   deemphasizeCounty();
   resetState();
+  unhighlightCounty();
+  unhighlightCircle();
+  hideToolTip();
   
   // change the zoom button or county dropdown based on view
   updateZoomOutButton(activeView);

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -29,8 +29,7 @@ function addStates(map, stateBounds) {
     .attr('id', function(d) {
       return d.properties.STATE_ABBV+'-lowres';
     })
-    .attr('d', buildPath)
-    .on('click', zoomToFromState);
+    .attr('d', buildPath);
     
   // add states
   map.select('#state-bounds')
@@ -47,7 +46,8 @@ function addStates(map, stateBounds) {
     })
     .attr('xlink:href', function(d) {
       return '#' + d + '-lowres';
-    });
+    })
+    .on('click', zoomToFromState);
 
   var nationBounds = buildPath.bounds(stateBounds);
   nationDims = {
@@ -81,8 +81,9 @@ function zoomToFromState(d, i, j, selection) {
   // could also use clickedState to set the URL, later
   var clickedView = selection.attr('id'); // need this in order to use background
   
-  if( clickedView !== 'map-background' ) {
-    // need to extract the state abbreviation from either county or state polygon
+  if( clickedView !== 'map-background' && clickedView.length > 2 ) {
+    // only do this if the clicked thing is not a state or map background
+    // need to extract the state abbreviation from the clicked county
     clickedView = selection.data()[0].properties.STATE_ABBV;
   }
   

--- a/js/states.js
+++ b/js/states.js
@@ -26,5 +26,6 @@ function updateStateBounds(error, stateBounds) {
     .data(stateBounds.features, function(d) {
       return d.properties.STATE_ABBV;
     })
-    .attr('d', buildPath);  
+    .attr('d', buildPath)
+    .on('click', zoomToFromState); //only clicks on mobile because of pointer-events
 }

--- a/js/styles.js
+++ b/js/styles.js
@@ -39,6 +39,14 @@ function foregroundState(selection, scale) {
     .transition()
     .duration(500)
     .style("stroke-width",  2/scale); // scale stroke-width
+    
+  if(waterUseViz.mode === "mobile") {
+    // turn off state pointer events for this state so that counties can be chosen
+    selection
+      .classed("state-click-on", false)
+      .classed("state-click-off", true);
+  }
+  
 }
 
 function backgroundState(selection, scale) {
@@ -69,6 +77,13 @@ function resetState() {
     .transition()
     .duration(750)
     .style("stroke-width", 1); // use null to get back to CSS
+  
+  if(waterUseViz.mode === "mobile") {
+    // turn on state pointer events for all states so that counties cannot be chosen
+    d3.selectAll('.state')
+      .classed("state-click-on", true)
+      .classed("state-click-off", false);
+  }
 }
 
 // on mouseover

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -10,11 +10,11 @@
   stroke-linecap: round;
 }
 
-.state-desktop {
+.state-click-off {
   pointer-events: none;
 }
 
-.state-mobile {
+.state-click-on {
   fill: white;
   fill-opacity: 0;
   pointer-events: fill;

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -8,7 +8,16 @@
   stroke: rgb(180,180,180);
   stroke-linejoin: round;
   stroke-linecap: round;
+}
+
+.state-desktop {
   pointer-events: none;
+}
+
+.state-mobile {
+  fill: white;
+  fill-opacity: 0;
+  pointer-events: fill;
 }
 
 .county {


### PR DESCRIPTION
This fixes #162 and #180. 

Mobile clicking behavior (in addition to dropdowns): when you're at national view, you can click a state to zoom in. While zoomed in, you can click adjacent states and be brought to them. Each time you go to a new state, county highlights are refreshed. On your zoomed in state, you can click the counties to highlight them.

Clicking a state or county changes and updates the drop down appropriately.

There's still a little weirdness with when the tooltips are there or go away, but we are planning to take them out, so I wasn't worried about it.

![mobile_clicking](https://user-images.githubusercontent.com/13220910/38753227-661e9fee-3f23-11e8-86bd-9246ff97bb9b.gif)
