### PR TITLE
show county bounds on state load

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -185,11 +185,9 @@ function loadInitialCounties() {
   // update the view once the county data is loaded
   
   function waitForCounties(error, results){
-    console.log(results);
     updateView(activeView);
   }
   
-  console.log('about to start county load');
   d3.queue()
     .defer(loadCountyBounds, activeView)
     .await(waitForCounties);

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -159,6 +159,10 @@ function fillMap() {
   // add the main, active map features
   addStates(map, stateBoundsUSA);
   
+  if(activeView !== "USA") {
+    loadInitialCounties();
+  }
+  
   // add the circles
   // CIRCLES-AS-CIRCLES
   addCircles(countyCentroids);
@@ -175,4 +179,18 @@ function fillMap() {
   // load county data, add and update county polygons.
   // it's OK if it's not done right away; it should be loaded by the time anyone tries to hover!
   updateCounties('USA');
+}
+
+function loadInitialCounties() {
+  // update the view once the county data is loaded
+  
+  function waitForCounties(error, results){
+    console.log(results);
+    updateView(activeView);
+  }
+  
+  console.log('about to start county load');
+  d3.queue()
+    .defer(loadCountyBounds, activeView)
+    .await(waitForCounties);
 }

--- a/js/counties.js
+++ b/js/counties.js
@@ -10,6 +10,7 @@ function updateCounties(state) {
 // make sure we have the USA data and then
 // call the next function (make sure we have this state stored in countyBoundsZoom and then visualize)
 function loadCountyBounds(state, callback) {
+  console.log("working on", state);
   // for now let's always load the county data all at once. later we can again split
   // into single-state files if that turns out to be useful for performance.
   if(state === 'USA') {

--- a/js/counties.js
+++ b/js/counties.js
@@ -10,7 +10,7 @@ function updateCounties(state) {
 // make sure we have the USA data and then
 // call the next function (make sure we have this state stored in countyBoundsZoom and then visualize)
 function loadCountyBounds(state, callback) {
-  console.log("working on", state);
+  
   // for now let's always load the county data all at once. later we can again split
   // into single-state files if that turns out to be useful for performance.
   if(state === 'USA') {

--- a/js/dropdown_selector.js
+++ b/js/dropdown_selector.js
@@ -103,8 +103,6 @@ function updateCountySelectorOptions(countyData) {
             highlightCounty(thisCountySel);
             highlightCircle(thisCountyData, activeCategory);
           }
-          
-          console.log("this will also update the data in the category legend");
         });
         
   // alphabetize counties

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -51,7 +51,6 @@ function addStates(map, stateBounds) {
   var newView = getHash('view');
   if(newView === null) { newView = 'USA'; }
   if(newView !== 'USA') {
-    console.log("zooming view");
     updateView(newView, fireAnalytics = false);
   }
 }
@@ -86,7 +85,7 @@ function updateView(newView, fireAnalytics) {
    if(fireAnalytics === undefined) {
       scale = true;
    }
-  console.log("updating view");
+  
   // update the global variable that stores the current view
   oldView = activeView;
   activeView = newView;

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -51,6 +51,7 @@ function addStates(map, stateBounds) {
   var newView = getHash('view');
   if(newView === null) { newView = 'USA'; }
   if(newView !== 'USA') {
+    console.log("zooming view");
     updateView(newView, fireAnalytics = false);
   }
 }
@@ -85,7 +86,7 @@ function updateView(newView, fireAnalytics) {
    if(fireAnalytics === undefined) {
       scale = true;
    }
-  
+  console.log("updating view");
   // update the global variable that stores the current view
   oldView = activeView;
   activeView = newView;

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -149,17 +149,15 @@ function updateView(newView, fireAnalytics) {
     var thisstate = d3.selectAll('.state')
       .filter(function(d) { return d === activeView; });
     
-    showCountyLines(statecounties);
+    showCountyLines(statecounties, scale = zoom_scale);
     emphasizeCounty(statecounties);
     backgroundState(otherstates, scale = zoom_scale);
     foregroundState(thisstate, scale = zoom_scale);
     
-    
   }
   var allcounties = d3.selectAll('.county');
   
-  allcounties.transition()
-    .duration(500) 
+  allcounties
     .style("stroke-width",  1/zoom_scale); // make all counties have scaled stroke-width
   
   // apply the transform (i.e., actually zoom in or out)

--- a/js/styles.js
+++ b/js/styles.js
@@ -21,9 +21,18 @@ function categoryToColor(category) {
 
 // on zoom in
 
-function showCountyLines(selection) {
+function showCountyLines(selection, scale) {
+  if(scale === undefined) {
+      scale = 1;
+   }
+  
   selection
-    .classed("show-county-bounds", true);
+    .classed("show-county-bounds", true) // used so that hideCountyLines can easily select
+    .style("stroke-width",  1/scale) // scale stroke-width
+    .transition()
+    .duration(500)
+    .style("stroke", "#bdbdbd"); // dark-ish grey
+    
 }
 function emphasizeCounty(selection) {
   selection
@@ -56,7 +65,7 @@ function backgroundState(selection, scale) {
 
 function hideCountyLines() {
   d3.selectAll('.show-county-bounds')
-    .classed("show-county-bounds", false); 
+    .style("stroke", null); // revert to stroke in .county definition
 }
 
 function deemphasizeCounty() {

--- a/js/styles.js
+++ b/js/styles.js
@@ -28,10 +28,7 @@ function showCountyLines(selection, scale) {
   
   selection
     .classed("show-county-bounds", true) // used so that hideCountyLines can easily select
-    .style("stroke-width",  1/scale) // scale stroke-width
-    .transition()
-    .duration(500)
-    .style("stroke", "#bdbdbd"); // dark-ish grey
+    .style("stroke-width",  1/scale); // don't wait to scale stroke-width after lines added
     
 }
 function emphasizeCounty(selection) {
@@ -65,7 +62,7 @@ function backgroundState(selection, scale) {
 
 function hideCountyLines() {
   d3.selectAll('.show-county-bounds')
-    .style("stroke", null); // revert to stroke in .county definition
+    .classed("show-county-bounds", false); // revert to stroke in .county definition
 }
 
 function deemphasizeCounty() {

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -16,10 +16,6 @@
   stroke: transparent;
 }
 
-.show-county-bounds {
-  stroke: #bdbdbd; /* dark-ish grey */
-}
-
 /* must be listed before highlighted-county*/
 /* THIS IS WHAT WILL MAKE THE ZOOMED IN STATE EMPHASIZED*/
 .emphasize-county {

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -16,6 +16,10 @@
   stroke: transparent;
 }
 
+.show-county-bounds {
+  stroke: #bdbdbd;
+}
+
 /* must be listed before highlighted-county*/
 /* THIS IS WHAT WILL MAKE THE ZOOMED IN STATE EMPHASIZED*/
 .emphasize-county {


### PR DESCRIPTION
This is an effort to fix #128. I don't think I really understand how the cache stuff in `counties.js` is working because loading just this one state's counties takes almost as much time as loading everything. I have a bunch of `console.log` in the code so that I can watch the order that things happen. Things are happening multiple times though and I think it's because `updateView` calls `updateCounties` which happens at the very beginning when states are added but there is not county data yet so no boundaries show up. Then I make a call to just those state bounds again with my addition of `loadInitialCounties`, and then everything starts loading with `updateCounties('USA')`. I know there's a better way to do this, just not sure what.

Here's how awful it is:

![load_county_boundries](https://user-images.githubusercontent.com/13220910/38838994-5234e024-419e-11e8-9c6d-18ca5d5932a7.gif)

2 hrs so far.