### PR TITLE
scale circle stroke-widths on zoom

### DIFF
--- a/js/circles.js
+++ b/js/circles.js
@@ -91,7 +91,6 @@ function highlightCircle(countyDatum, category) {
     .attr('cx', projectX([countyDatum.lon, countyDatum.lat]))
     .attr('cy', projectY([countyDatum.lon, countyDatum.lat]))
     .attr('r', scaleCircles(countyDatum[category]))
-    .style('stroke', categoryToColor(category))
     .style('fill', categoryToColor(category));
   
 }

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -163,6 +163,11 @@ function updateView(newView, fireAnalytics) {
   unhighlightCircle();
   updateLegendTextToView();
   
+  // only reset stroke when zooming back out
+  if(activeView === "USA") {
+    resetCircleStroke();
+  }
+
   // change the zoom button or county dropdown based on view
   updateZoomOutButton(activeView);
   updateCountySelectorDropdown(activeView);
@@ -176,13 +181,16 @@ function updateView(newView, fireAnalytics) {
       .filter(function(d) { return d !== activeView; });
     var thisstate = d3.selectAll('.state')
       .filter(function(d) { return d === activeView; });
+    var wucircles = d3.selectAll('.wu-circle');
     
     showCountyLines(statecounties, scale = zoom_scale);
     emphasizeCounty(statecounties);
     backgroundState(otherstates, scale = zoom_scale);
     foregroundState(thisstate, scale = zoom_scale);
+    scaleCircleStroke(wucircles, scale = zoom_scale);
     
   }
+  
   var allcounties = d3.selectAll('.county');
   
   allcounties

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -162,11 +162,6 @@ function updateView(newView, fireAnalytics) {
   unhighlightCounty();
   unhighlightCircle();
   updateLegendTextToView();
-  
-  // only reset stroke when zooming back out
-  if(activeView === "USA") {
-    resetCircleStroke();
-  }
 
   // change the zoom button or county dropdown based on view
   updateZoomOutButton(activeView);
@@ -189,6 +184,9 @@ function updateView(newView, fireAnalytics) {
     foregroundState(thisstate, scale = zoom_scale);
     scaleCircleStroke(wucircles, scale = zoom_scale);
     
+  } else {
+    // only reset stroke when zooming back out
+    resetCircleStroke();
   }
   
   var allcounties = d3.selectAll('.county');

--- a/js/styles.js
+++ b/js/styles.js
@@ -109,3 +109,15 @@ function unhighlightCounty() {
     .classed("highlighted-county", false);
 }
 
+function scaleCircleStroke(selection, scale) {
+  selection
+    .style("stroke-width", 2/scale+"px");
+}
+
+function resetCircleStroke() {
+  //resets stroke-width to whatever is coming from CSS
+  d3.selectAll('.wu-circle')
+    .transition()
+    .delay(500) // delay until > 1/2 way through zoom out
+    .style("stroke-width", null);
+}


### PR DESCRIPTION
Fixes #154. I didn't really understand what you guys were talking about with scaling in transform vs by radius for the stroke width, but this was how I was picturing the scaling.

![circle_outline_scaling](https://user-images.githubusercontent.com/13220910/39009413-26a9e46a-43d1-11e8-9be2-5e1d5d859749.gif)


