### PR TITLE
delay for mouseouts

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -1,3 +1,5 @@
+var mouseTimer;
+
 function addButtons() {
   var buttonBox = waterUseViz.elements.buttonBox = svg.append('g')
     .attr('id', 'button-container');
@@ -34,10 +36,13 @@ function addButtons() {
       updateCategory(d.toLowerCase(), activeCategory);
     })
     .on('mouseover', function(d){
+      clearTimeout(mouseTimer); // cancel last "mouseout" action before it does anything
       showCategory(d.toLowerCase(), activeCategory, action = 'mouseover');
     })
     .on('mouseout', function(d){
-      showCategory(activeCategory, d.toLowerCase(), action = 'mouseout');
+      mouseTimer = setTimeout(function() {
+        showCategory(activeCategory, d.toLowerCase(), action = 'mouseout'); 
+      }, 200);
     });
   
   // button category labels


### PR DESCRIPTION
This mostly fixes #160 BUT I can't figure out how to rework the `showButtons` function to include the scenario when you mouseout of some category and then immediately back onto the currently selected one. In this scenario, the timeout is cleared out but then on the mouseover the previous and current categories are the same so it skips changing the buttons back.

Here is the before:
![category_switching_before](https://user-images.githubusercontent.com/13220910/39018469-b875ce9e-43eb-11e8-81ad-5bfc4e3bf49c.gif)


Here is where I'm at:
![category_jumps](https://user-images.githubusercontent.com/13220910/39018471-ba877ed0-43eb-11e8-9b0b-481b78330d7d.gif)
