### PR TITLE
use final data

### DIFF
--- a/viz.yaml
+++ b/viz.yaml
@@ -141,7 +141,7 @@ fetch:
     reader: excel
     fetcher: sciencebase
     remoteItemId: "5ab154b1e4b081f61ab26420"
-    remoteFilename: "usco2015v2.0-dataviz.xlsx"
+    remoteFilename: "usco2015v2.0_FINAL-dataviz.xlsx"
     
 process:
   -


### PR DESCRIPTION
Fixes #218. Leaving the older data there, but updated final name according to how NWULT did. New file on ScienceBase: https://www.sciencebase.gov/catalog/item/5ab154b1e4b081f61ab26420.