### PR TITLE
St thomas

### DIFF
--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -96,7 +96,7 @@ function zoomToFromState(d, i, j, selection) {
     // if they clicked on a different state, prepare to zoom in
     newView = clickedView;
   }
-
+  
   // zoom to the new view
   updateView(newView);
 }
@@ -117,43 +117,42 @@ function updateView(newView, fireAnalytics) {
     updateStateSelector(activeView);
   } 
   
-  // determine the center point and scaling for the new view
-  var x, y;
-  if(activeView === 'USA') {
-    x = waterUseViz.dims.map.width / 2;
-    y = waterUseViz.dims.map.height / 2;
-    zoom_scale = 1;
-  } else {
-    var stateGeom, centroid, x0, y0, x1, y1, stateDims;
-    
-    // find the state data we want to zoom to
-    stateGeom = stateBoundsUSA.features.filter(function(d) {
-      return d.properties.STATE_ABBV === activeView;
-    })[0];
-    
-    // find the center point to zoom to
-    centroid = buildPath.centroid(stateGeom);
-    x = centroid[0];
-    y = centroid[1];
-    
-    // find the maximum zoom (up to nation bounding box size) that keeps the
-    // whole state in view
-    [[x0,y0],[x1,y1]] = buildPath.bounds(stateGeom);
-    stateDims = {
-      width: 2 * d3.max([ x1 - x, x - x0]),
-      height: 2 * d3.max([ y1 - y, y - y0])
-    };
-    zoom_scale = d3.min([
-      nationDims.height/stateDims.height,
-      nationDims.width/stateDims.width]);
-  }
-
   // update the geospatial data for the upcoming resolution
   updateCounties(activeView);
   updateStates(activeView);
   
-  // set the styling: setting by adding or removing class, so d3 transitions not used
+  // ensure we have the zoom parameters (they're in the state zoom data) and apply the zoom
+  updateStateData(newView, function() {
+    applyZoomAndStyle(newView);
+  });
   
+  // record the change for analytics. don't need timeout for view change   
+  if(fireAnalytics) {
+    gtag('event', 'update view', {
+      'event_category': 'figure',
+      'event_label': 'newView=' + newView + '; oldView=' +     oldView + '; category=' + activeCategory
+    });
+  }    
+}
+
+function applyZoomAndStyle(newView) {
+  // determine the center point and scaling for the new view
+  var zoom;
+  if(activeView === 'USA') {
+    zoom = {
+      x: waterUseViz.dims.map.width / 2,
+      y: waterUseViz.dims.map.height / 2,
+      s: 1
+    };
+  } else {
+    // find the state data we want to zoom to
+    var stateGeom = stateBoundsZoom.features.filter(function(d) {
+      return d.properties.STATE_ABBV === activeView;
+    })[0];
+    // the ZOOM property contains x, y, and s
+    zoom = stateGeom.properties.ZOOM;
+  }
+
   // reset counties each time a zoom changes
   // cannot go inside first if because panning to adjacent state won't reset
   hideCountyLines();
@@ -178,11 +177,11 @@ function updateView(newView, fireAnalytics) {
       .filter(function(d) { return d === activeView; });
     var wucircles = d3.selectAll('.wu-circle');
     
-    showCountyLines(statecounties, scale = zoom_scale);
+    showCountyLines(statecounties, scale = zoom.s);
     emphasizeCounty(statecounties);
-    backgroundState(otherstates, scale = zoom_scale);
-    foregroundState(thisstate, scale = zoom_scale);
-    scaleCircleStroke(wucircles, scale = zoom_scale);
+    backgroundState(otherstates, scale = zoom.s);
+    foregroundState(thisstate, scale = zoom.s);
+    scaleCircleStroke(wucircles, scale = zoom.s);
     
   } else {
     // only reset stroke when zooming back out
@@ -192,25 +191,16 @@ function updateView(newView, fireAnalytics) {
   var allcounties = d3.selectAll('.county');
   
   allcounties
-    .style("stroke-width",  1/zoom_scale); // make all counties have scaled stroke-width
+    .style("stroke-width",  1/zoom.s); // make all counties have scaled stroke-width
   
   // apply the transform (i.e., actually zoom in or out)
   map.transition()
     .duration(750)
     .attr('transform',
       "translate(" + waterUseViz.dims.map.width / 2 + "," + waterUseViz.dims.map.height / 2 + ")"+
-      "scale(" + zoom_scale + ")" +
-      "translate(" + (waterUseViz.dims.map.x0/zoom_scale - x) + "," + -y + ")");
-      
-  // record the change for analytics. don't need timeout for view change   
-  if(fireAnalytics) {
-    gtag('event', 'update view', {
-      'event_category': 'figure',
-      'event_label': 'newView=' + newView + '; oldView=' +     oldView + '; category=' + activeCategory
-    });
-  }    
+      "scale(" + zoom.s + ")" +
+      "translate(" + (waterUseViz.dims.map.x0/zoom.s - zoom.x) + "," + -zoom.y + ")");
 }
-
 
 function updateCategory(category, prevCategory) {
   if(category === prevCategory) {

--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -59,26 +59,30 @@ targets:
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
   cache/pre_state_boundaries_USA.json:
+    depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e6),
+      outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(TRUE),
       county_topojson='cache/pre_county_boundaries_USA.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
   
   cache/pre_all_boundaries_USA.json:
+    depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
-      outfile=target_name, objects=I('states-and-counties'), quantize=I(1e6),
+      outfile=target_name, objects=I('states-and-counties'), quantize=I(1e6), zoom_dims=I(FALSE),
       county_topojson='cache/pre_county_boundaries_USA.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
       
   cache/pre_state_boundaries_zoom.json:
+    depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e8),
+      outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
       county_topojson='cache/pre_county_boundaries_zoom.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
   
   cache/pre_all_boundaries_zoom.json:
+    depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
-      outfile=target_name, objects=I('states-and-counties'), quantize=I(1e8),
+      outfile=target_name, objects=I('states-and-counties'), quantize=I(1e8), zoom_dims=I(FALSE),
       county_topojson='cache/pre_county_boundaries_zoom.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
   

--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -61,7 +61,7 @@ targets:
   cache/pre_state_boundaries_USA.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(TRUE),
+      outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(FALSE),
       county_topojson='cache/pre_county_boundaries_USA.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
   

--- a/scripts/preprocess/custom_projection.js
+++ b/scripts/preprocess/custom_projection.js
@@ -1,0 +1,279 @@
+var d3 = require('d3');
+
+var epsilon = 1e-6;
+
+// The projections must have mutually exclusive clip regions on the sphere,
+// as this will avoid emitting interleaving lines and polygons.
+function multiplex$1(streams) {
+  var n = streams.length;
+  return {
+    point: function(x, y) { var i = -1; while (++i < n) streams[i].point(x, y); },
+    sphere: function() { var i = -1; while (++i < n) streams[i].sphere(); },
+    lineStart: function() { var i = -1; while (++i < n) streams[i].lineStart(); },
+    lineEnd: function() { var i = -1; while (++i < n) streams[i].lineEnd(); },
+    polygonStart: function() { var i = -1; while (++i < n) streams[i].polygonStart(); },
+    polygonEnd: function() { var i = -1; while (++i < n) streams[i].polygonEnd(); }
+  };
+}
+
+var custom_projection = module.exports = {
+  // A composite projection for the United States, configured by default for
+  // 960×500. Also works quite well at 960×600 with scale 1285. The set of
+  // standard parallels for each region comes from USGS, which is published here:
+  // http://egsc.usgs.gov/isb/pubs/MapProjections/projections.html#albers
+  albersUsaTerritories: function () {
+    var cache,
+        cacheStream,
+        lower48 = d3.geoAlbers(), lower48Point,
+        alaska = d3.geoConicEqualArea().rotate([154, 0]).center([-2, 58.5]).parallels([55, 65]), alaskaPoint, // EPSG:3338
+        hawaii = d3.geoConicEqualArea().rotate([157, 0]).center([-3, 19.9]).parallels([8, 18]), hawaiiPoint, // ESRI:102007
+        puertoRico = d3.geoConicEqualArea().rotate([66, 0]).center([0, 18]).parallels([8, 18]), puertoRicoPoint, //Taken from https://bl.ocks.org/mbostock/5629120
+        point, pointStream = {point: function(x, y) { point = [x, y]; }};
+  
+        /*
+        var puertoRicoBbox = [[-68.3, 19], [-63.9, 17]];
+        */
+  
+    function albersUsa(coordinates) {
+      var x = coordinates[0], y = coordinates[1];
+  
+      return point = null, (lower48Point.point(x, y), point) ||
+          (alaskaPoint.point(x, y), point)  ||
+          (hawaiiPoint.point(x, y), point)  ||
+          (puertoRicoPoint.point(x, y), point);
+    }
+  
+    albersUsa.invert = function(coordinates) {
+  
+      var k = lower48.scale(),
+          t = lower48.translate(),
+          x = (coordinates[0] - t[0]) / k,
+          y = (coordinates[1] - t[1]) / k;
+          /*
+          //How are the return values calculated:
+          console.info("******");
+          var c0 = puertoRico(puertoRicoBbox[0]);
+          var x0 = (c0[0] - t[0]) / k;
+          var y0 = (c0[1] - t[1]) / k;
+          console.info("p0 puertoRico", x0 + ' - ' + y0);
+          var c1 = puertoRico(puertoRicoBbox[1]);
+          var x1 = (c1[0] - t[0]) / k;
+          var y1 = (c1[1] - t[1]) / k;
+          console.info("p1 puertoRico", x1 + ' - ' + y1);
+          c0 = samoa(samoaBbox[0]);
+          x0 = (c0[0] - t[0]) / k;
+          y0 = (c0[1] - t[1]) / k;
+          console.info("p0 samoa", x0 + ' - ' + y0);
+          c1 = samoa(samoaBbox[1]);
+          x1 = (c1[0] - t[0]) / k;
+          y1 = (c1[1] - t[1]) / k;
+          console.info("p1 samoa", x1 + ' - ' + y1);
+          c0 = guam(guamBbox[0]);
+          x0 = (c0[0] - t[0]) / k;
+          y0 = (c0[1] - t[1]) / k;
+          console.info("p0 guam", x0 + ' - ' + y0);
+          c1 = guam(guamBbox[1]);
+          x1 = (c1[0] - t[0]) / k;
+          y1 = (c1[1] - t[1]) / k;
+          console.info("p1 guam", x1 + ' - ' + y1);
+          */
+  
+      return (y >= 0.120 && y < 0.234 && x >= -0.425 && x < -0.214 ? alaska
+          : y >= 0.166 && y < 0.234 && x >= -0.214 && x < -0.115 ? hawaii
+          : y >= 0.130 && y < 0.190 && x >= 0.270 && x < 0.410 ? puertoRico
+          : lower48).invert(coordinates);
+  
+    };
+  
+    albersUsa.stream = function(stream) {
+      return cache && cacheStream === stream ? cache : cache = multiplex$1([lower48.stream(cacheStream = stream), alaska.stream(stream), hawaii.stream(stream), puertoRico.stream(stream)]);
+    };
+  
+    albersUsa.precision = function(_) {
+      if (!arguments.length) {return lower48.precision();}
+      lower48.precision(_);
+      alaska.precision(_);
+      hawaii.precision(_);
+      puertoRico.precision(_);
+      return reset();
+    };
+  
+    albersUsa.scale = function(_) {
+      if (!arguments.length) {return lower48.scale();}
+      lower48.scale(_);
+      alaska.scale(_ * 0.35);
+      hawaii.scale(_);
+      puertoRico.scale(_ * 3);
+      return albersUsa.translate(lower48.translate());
+    };
+  
+    albersUsa.translate = function(_) {
+      if (!arguments.length) {return lower48.translate();}
+      var k = lower48.scale(), x = +_[0], y = +_[1];
+  
+      /*
+      var c0 = puertoRico.translate([x + 0.350 * k, y + 0.224 * k])(puertoRicoBbox[0]);
+      var x0 = (x - c0[0]) / k;
+      var y0 = (y - c0[1]) / k;
+      var c1 = puertoRico.translate([x + 0.350 * k, y + 0.224 * k])(puertoRicoBbox[1]);
+      var x1 = (x - c1[0]) / k;
+      var y1 = (y - c1[1]) / k;
+      console.info('puertoRico: p0: ' + x0 + ', ' + y0 + ' , p1: ' + x1 + ' - ' + y1);
+      console.info('.clipExtent([[x '+
+       (x0<0?'+ ':'- ') + Math.abs(x0.toFixed(4))+
+       ' * k + epsilon, y '+
+       (y0<0?'+ ':'- ') + Math.abs(y0.toFixed(4))+
+       ' * k + epsilon],[x '+
+       (x1<0?'+ ':'- ') + Math.abs(x1.toFixed(4))+
+       ' * k - epsilon, y '+
+       (y1<0?'+ ':'- ') + Math.abs(y1.toFixed(4))+
+       ' * k - epsilon]])');
+        c0 = samoa.translate([x - 0.492 * k, y + 0.09 * k])(samoaBbox[0]);
+        x0 = (x - c0[0]) / k;
+        y0 = (y - c0[1]) / k;
+        c1 = samoa.translate([x - 0.492 * k, y + 0.09 * k])(samoaBbox[1]);
+        x1 = (x - c1[0]) / k;
+        y1 = (y - c1[1]) / k;
+       console.info('samoa: p0: ' + x0 + ', ' + y0 + ' , p1: ' + x1 + ' - ' + y1);
+       console.info('.clipExtent([[x '+
+        (x0<0?'+ ':'- ') + Math.abs(x0.toFixed(4))+
+        ' * k + epsilon, y '+
+        (y0<0?'+ ':'- ') + Math.abs(y0.toFixed(4))+
+        ' * k + epsilon],[x '+
+        (x1<0?'+ ':'- ') + Math.abs(x1.toFixed(4))+
+        ' * k - epsilon, y '+
+        (y1<0?'+ ':'- ') + Math.abs(y1.toFixed(4))+
+        ' * k - epsilon]])');
+        c0 = guam.translate([x - 0.408 * k, y + 0.018 * k])(guamBbox[0]);
+        x0 = (x - c0[0]) / k;
+        y0 = (y - c0[1]) / k;
+        c1 = guam.translate([x - 0.408 * k, y + 0.018 * k])(guamBbox[1]);
+        x1 = (x - c1[0]) / k;
+        y1 = (y - c1[1]) / k;
+       console.info('guam: p0: ' + x0 + ', ' + y0 + ' , p1: ' + x1 + ' - ' + y1);
+       console.info('.clipExtent([[x '+
+        (x0<0?'+ ':'- ') + Math.abs(x0.toFixed(4))+
+        ' * k + epsilon, y '+
+        (y0<0?'+ ':'- ') + Math.abs(y0.toFixed(4))+
+        ' * k + epsilon],[x '+
+        (x1<0?'+ ':'- ') + Math.abs(x1.toFixed(4))+
+        ' * k - epsilon, y '+
+        (y1<0?'+ ':'- ') + Math.abs(y1.toFixed(4))+
+        ' * k - epsilon]])');
+        */
+  
+      lower48Point = lower48
+          .translate(_)
+          .clipExtent([[x - 0.455 * k, y - 0.238 * k], [x + 0.455 * k, y + 0.238 * k]])
+          .stream(pointStream);
+  
+      alaskaPoint = alaska
+          .translate([x - 0.307 * k, y + 0.201 * k])
+          .clipExtent([[x - 0.425 * k + epsilon, y + 0.120 * k + epsilon], [x - 0.214 * k - epsilon, y + 0.233 * k - epsilon]])
+          .stream(pointStream);
+  
+      hawaiiPoint = hawaii
+          .translate([x - 0.205 * k, y + 0.212 * k])
+          .clipExtent([[x - 0.214 * k + epsilon, y + 0.166 * k + epsilon], [x - 0.115 * k - epsilon, y + 0.233 * k - epsilon]])
+          .stream(pointStream);
+  
+      puertoRicoPoint = puertoRico
+          .translate([x + 0.340 * k, y + 0.170 * k])
+          .clipExtent([[x + 0.270 * k + epsilon, y + 0.130 * k + epsilon],[x + 0.410 * k - epsilon, y + 0.190 * k - epsilon]])
+          .stream(pointStream);
+  
+  
+      return reset();
+    };
+  
+    albersUsa.fitExtent = function(extent, object) {
+      return fitExtent(albersUsa, extent, object);
+    };
+  
+    albersUsa.fitSize = function(size, object) {
+      return fitSize(albersUsa, size, object);
+    };
+  
+    function reset() {
+      cache = cacheStream = null;
+      return albersUsa;
+    }
+  
+    albersUsa.drawCompositionBorders = function(context) {
+  
+      /*
+      console.info("CLIP EXTENT hawaii: ", hawaii.clipExtent());
+      console.info("UL BBOX:", lower48.invert([hawaii.clipExtent()[0][0], hawaii.clipExtent()[0][1]]));
+      console.info("UR BBOX:", lower48.invert([hawaii.clipExtent()[1][0], hawaii.clipExtent()[0][1]]));
+      console.info("LD BBOX:", lower48.invert([hawaii.clipExtent()[1][0], hawaii.clipExtent()[1][1]]));
+      console.info("LL BBOX:", lower48.invert([hawaii.clipExtent()[0][0], hawaii.clipExtent()[1][1]]));
+      console.info("CLIP EXTENT alaska: ", alaska.clipExtent());
+      console.info("UL BBOX:", lower48.invert([alaska.clipExtent()[0][0], alaska.clipExtent()[0][1]]));
+      console.info("UR BBOX:", lower48.invert([alaska.clipExtent()[1][0], alaska.clipExtent()[0][1]]));
+      console.info("LD BBOX:", lower48.invert([alaska.clipExtent()[1][0], alaska.clipExtent()[1][1]]));
+      console.info("LL BBOX:", lower48.invert([alaska.clipExtent()[0][0], alaska.clipExtent()[1][1]]));
+      console.info("CLIP EXTENT puertoRico: ", puertoRico.clipExtent());
+      console.info("UL BBOX:", lower48.invert([puertoRico.clipExtent()[0][0], puertoRico.clipExtent()[0][1]]));
+      console.info("UR BBOX:", lower48.invert([puertoRico.clipExtent()[1][0], puertoRico.clipExtent()[0][1]]));
+      console.info("LD BBOX:", lower48.invert([puertoRico.clipExtent()[1][0], puertoRico.clipExtent()[1][1]]));
+      console.info("LL BBOX:", lower48.invert([puertoRico.clipExtent()[0][0], puertoRico.clipExtent()[1][1]]));
+      console.info("CLIP EXTENT samoa: ", samoa.clipExtent());
+      console.info("UL BBOX:", lower48.invert([samoa.clipExtent()[0][0], samoa.clipExtent()[0][1]]));
+      console.info("UR BBOX:", lower48.invert([samoa.clipExtent()[1][0], samoa.clipExtent()[0][1]]));
+      console.info("LD BBOX:", lower48.invert([samoa.clipExtent()[1][0], samoa.clipExtent()[1][1]]));
+      console.info("LL BBOX:", lower48.invert([samoa.clipExtent()[0][0], samoa.clipExtent()[1][1]]));
+      console.info("CLIP EXTENT guam: ", guam.clipExtent());
+      console.info("UL BBOX:", lower48.invert([guam.clipExtent()[0][0], guam.clipExtent()[0][1]]));
+      console.info("UR BBOX:", lower48.invert([guam.clipExtent()[1][0], guam.clipExtent()[0][1]]));
+      console.info("LD BBOX:", lower48.invert([guam.clipExtent()[1][0], guam.clipExtent()[1][1]]));
+      console.info("LL BBOX:", lower48.invert([guam.clipExtent()[0][0], guam.clipExtent()[1][1]]));
+      */
+  
+      var ulhawaii = lower48([-110.4641, 28.2805]);
+      var urhawaii = lower48([-104.0597, 28.9528]);
+      var ldhawaii = lower48([-103.7049, 25.1031]);
+      var llhawaii = lower48([-109.8337, 24.4531]);
+  
+      var ulalaska = lower48([ -124.4745, 28.1407]);
+      var uralaska = lower48([ -110.931, 30.8844]);
+      var ldalaska = lower48([-109.8337, 24.4531]);
+      var llalaska = lower48([-122.4628, 21.8562]);
+  
+      var ulpuertoRico = lower48([-76.8579, 25.1544]);
+      var urpuertoRico = lower48([-72.429, 24.2097]);
+      var ldpuertoRico = lower48([-72.8265, 22.7056]);
+      var llpuertoRico = lower48([-77.1852, 23.6392]);
+  
+      context.moveTo(ulhawaii[0], ulhawaii[1]);
+      context.lineTo(urhawaii[0], urhawaii[1]);
+      context.lineTo(ldhawaii[0], ldhawaii[1]);
+      context.lineTo(ldhawaii[0], ldhawaii[1]);
+      context.lineTo(llhawaii[0], llhawaii[1]);
+      context.closePath();
+  
+      context.moveTo(ulalaska[0], ulalaska[1]);
+      context.lineTo(uralaska[0], uralaska[1]);
+      context.lineTo(ldalaska[0], ldalaska[1]);
+      context.lineTo(ldalaska[0], ldalaska[1]);
+      context.lineTo(llalaska[0], llalaska[1]);
+      context.closePath();
+  
+      context.moveTo(ulpuertoRico[0], ulpuertoRico[1]);
+      context.lineTo(urpuertoRico[0], urpuertoRico[1]);
+      context.lineTo(ldpuertoRico[0], ldpuertoRico[1]);
+      context.lineTo(ldpuertoRico[0], ldpuertoRico[1]);
+      context.lineTo(llpuertoRico[0], llpuertoRico[1]);
+      context.closePath();
+  
+    };
+    albersUsa.getCompositionBorders = function() {
+      var context = d3Path.path();
+      this.drawCompositionBorders(context);
+      return context.toString();
+  
+    };
+  
+  
+    return albersUsa.scale(1070);
+  }
+};

--- a/scripts/preprocess/process_counties_to_states.R
+++ b/scripts/preprocess/process_counties_to_states.R
@@ -2,6 +2,7 @@ process_counties_to_states <- function(
   outfile='cache/pre_state_boundaries_USA.json',
   objects='states and counties',
   quantize=1e8,
+  zoom_dims=FALSE,
   county_topojson='cache/pre_county_boundaries_USA.json',
   state_dict_file='cache/pre_state_dictionary.json',
   script_file = 'scripts/preprocess/process_counties_to_states.js') {
@@ -14,6 +15,7 @@ process_counties_to_states <- function(
     sprintf('--statedict %s', state_dict_file),
     sprintf('--outfile %s',outfile),
     sprintf('--quantize "%0.0f"', quantize),
+    sprintf('--zoomdims %s', if(zoom_dims) 'yes' else 'no'),
     sprintf('--objects "%s"', objects))
   message(cmd)
   # for the following line to work, the system environment variable PATH should

--- a/scripts/preprocess/process_counties_to_states.js
+++ b/scripts/preprocess/process_counties_to_states.js
@@ -5,16 +5,40 @@
 // in the system() call in process_counties_to_states().)
 console.log("NODE_PATH: " + process.env.NODE_PATH);
 
-// need to run npm install -g topojson geojson yargs if you haven't already
+// you need to run "npm i -g topojson geojson d3 yargs" if you haven't already
 var fs = require('fs');
 var topojson = require('topojson');
 var geojson = require('geojson');
+var d3 = require('d3');
 const argv = require('yargs').argv;
 
 // read in the topojson file with county boundaries and the json dictionary of state names and IDs
 var countyTopo = JSON.parse(fs.readFileSync(argv.counties, 'utf8'));
 var stateDict = JSON.parse(fs.readFileSync(argv.statedict, 'utf8'));
 
+// load the projection we'll be using in the main vizzy.
+// note that we're using a copy of custom_project.js. this is because we needed to reformat
+// into a module to be able to use node's require() function to load the script. I tried
+// jquery.getScript() and failed; require() works great except you need the module formatting.
+var proj = require('./custom_projection.js');
+
+// define the projection. this code is copied from build_map.js
+var waterUseViz = {
+  dims: {
+    map: {
+      width: 1000,
+      height: 700
+    }
+  }
+};
+var projection = proj.albersUsaTerritories()
+  .scale([1200])
+  .translate([waterUseViz.dims.map.width / 2, waterUseViz.dims.map.height / 2]);
+  // default is .rotate([96,0]) to center on US (we want this)
+var buildPath = d3.geoPath()
+  .projection(projection);
+
+// here's the main function where we compute state-level information, including centroids and zoom info
 function mergeCounties(countyTopo, stateDict) {
   // get an array of state FIPS codes
   var stateAbbvs = [];
@@ -22,9 +46,19 @@ function mergeCounties(countyTopo, stateDict) {
     stateAbbvs.push(d.STATE_ABBV);
   });
   
-  // for each state FIPS, find and merge all relevant counties
+  // start on the calculation of zoom parameters; here we just need the dims for the whole nation
+  var nation = topojson.merge(countyTopo, countyTopo.objects.counties.geometries);
+  var nationBounds = buildPath.bounds(nation);
+  var nationDims = {
+    width: nationBounds[1][0] - nationBounds[0][0],
+    height: nationBounds[1][1] - nationBounds[0][1]
+  };
+  
+  // for each state FIPS, find and merge all relevant counties and compute zoom parameters
   var states = [];
   stateAbbvs.forEach(function(abbv) {
+    
+    // find and merge all relevant counties
     var counties = countyTopo.objects.counties.geometries.filter(function(d) {
       return d.properties.STATE_ABBV === abbv;
     });
@@ -34,6 +68,30 @@ function mergeCounties(countyTopo, stateDict) {
     })[0];
     state.STATE_NAME = stateInfo.STATE_NAME;
     state.STATE_ABBV = stateInfo.STATE_ABBV;
+    
+    // compute zoom parameters
+    [cx, cy] = buildPath.centroid(state);
+    // find the maximum zoom (up to nation bounding box size) that keeps the
+    // whole state in view
+    [[x0,y0],[x1,y1]] = buildPath.bounds(state);
+    stateDims = {
+      width: 2 * d3.max([ x1 - cx, cx - x0]),
+      height: 2 * d3.max([ y1 - cy, cy - y0])
+    };
+    zoom_scale = d3.min([
+      nationDims.height/stateDims.height,
+      nationDims.width/stateDims.width]);
+    
+    // combine the results into a vector. round numbers and use short names to save on file size
+    function precisionRound(number, precision) {
+      var factor = Math.pow(10, precision);
+      return Math.round(number * factor) / factor;
+    }
+    state.ZOOM ={
+      x: Math.round(cx),
+      y: Math.round(cy),
+      s: precisionRound(zoom_scale, 3)
+    };
     states.push(state);
   });
   
@@ -42,13 +100,19 @@ function mergeCounties(countyTopo, stateDict) {
   performance and strategy question whether we ought to be combining everything (faster
   overall load time) or splitting so that we can load states first for a nice quick view,
   counties later. going with the second option for now. */
+  var include;
+  if(argv.zoomdims === 'yes') {
+    include = ['STATE_NAME','STATE_ABBV','ZOOM'];
+  } else {
+    include = ['STATE_NAME','STATE_ABBV'];
+  }
   statesGeojson = geojson.parse(
     states,
-    { MultiPolygon: 'coordinates', include: ['STATE_NAME','STATE_ABBV'] },
+    { MultiPolygon: 'coordinates', include: include },
     crs = { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } });
   return statesGeojson;
 }
-statesGeojson = mergeCounties(countyTopo, stateDict);
+states = mergeCounties(countyTopo, stateDict);
 
 // write the output to topojson file
 var outTopojson;


### PR DESCRIPTION
Resolves #179, zoom to all 3 Virgin Islands instead of just one.

![180423-st-thomas](https://user-images.githubusercontent.com/12039957/39159667-a6ea0f2c-471b-11e8-9f7b-ea95db96fec5.gif)

The problem was that the simplified state boundaries we were using to calculate zoom parameters were too simple - they had simplified away 2 of the 3 Virgin Islands and so were ~correctly zooming to the one VI represented by those bounds.

In hindsight I think I could have simply done the data/callback work I ended up doing in map_utils.js and then computing the zoom scale and x/y values from the high-res state boundaries that would have then been available. But because I didn't see that right away, I ended up also pushing the calculation of centroids and zoom scale into the vizlab preprocessing step; now those parameters are packaged with the hi-res state bounds (where they were calculated). This represents more work than I strictly needed to do to resolve #179 , had I known in advance what was needed, but it's not all bad - I imagine that the preprocessing might make the zoom slightly faster, and also I've learned a lot about how we could pre-project all the coordinates in the entire viz (information we may or may not use for this viz but can definitely use in future vizzies).