### PR TITLE
don't revert to lo-res county bounds on zoom out

### DIFF
--- a/js/counties.js
+++ b/js/counties.js
@@ -92,9 +92,15 @@ function cacheCountyBounds(state, callback) {
 function displayCountyBounds(error, activeCountyData) {
     if(error) throw error;
     
+    currentCountyBounds = map.select('#county-bounds').selectAll('.county');
+    
+    // return immediately if we already have the counties defined and we're zooming out
+    if(currentCountyBounds._groups[0].length > 3000 & activeCountyData === countyBoundsUSA) {
+      return;
+    }
+    
     // attach data
-    var countyBounds = map.select('#county-bounds')
-      .selectAll(".county")
+    var countyBounds = currentCountyBounds
       .data(activeCountyData, function(d) {
         return d.properties.GEOID;
       });


### PR DESCRIPTION
Following up on https://github.com/USGS-VIZLAB/water-use-15/pull/224#discussion_r183824081

This PR: Without return to lo-res county bounds every time you zoom out, AK-CA-WI-MS-GA:
[Violation] 'requestAnimationFrame' handler took 86ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 136ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 53ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 52ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 67ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 278ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 310ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 413ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 578ms
[Violation] Forced reflow while executing JavaScript took 237ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 64ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 455ms
[Violation] Forced reflow while executing JavaScript took 184ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 445ms
[Violation] Forced reflow while executing JavaScript took 181ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 453ms
[Violation] Forced reflow while executing JavaScript took 183ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 457ms
[Violation] Forced reflow while executing JavaScript took 184ms
![image](https://user-images.githubusercontent.com/12039957/39213000-2bcdaa88-47c5-11e8-8044-a9ab0aeb3692.png)
Sum of violations = 4630 ms

Status quo: With return to lo-res county bounds every time you zoom out, AK-CA-WI-MS-GA:
[Violation] 'load' handler took 319ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 295ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 323ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 293ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 444ms
[Violation] Forced reflow while executing JavaScript took 181ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 268ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 437ms
[Violation] Forced reflow while executing JavaScript took 179ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 251ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 435ms
[Violation] Forced reflow while executing JavaScript took 178ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 259ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 440ms
[Violation] Forced reflow while executing JavaScript took 180ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 256ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 439ms
[Violation] Forced reflow while executing JavaScript took 179ms
![image](https://user-images.githubusercontent.com/12039957/39213108-8166b872-47c5-11e8-9dcf-629b22910026.png)
Sum of violations = 5356 ms

Again, this PR: Without return to lo-res county bounds every time you zoom out, CA-AL-WY-NY-CA-AL-WY-NY:
[Violation] 'load' handler took 169ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 307ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 339ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 445ms
[Violation] Forced reflow while executing JavaScript took 180ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 456ms
[Violation] Forced reflow while executing JavaScript took 187ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 432ms
[Violation] Forced reflow while executing JavaScript took 178ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 453ms
[Violation] Forced reflow while executing JavaScript took 185ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 440ms
[Violation] Forced reflow while executing JavaScript took 181ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 442ms
[Violation] Forced reflow while executing JavaScript took 181ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 445ms
[Violation] Forced reflow while executing JavaScript took 180ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 433ms
[Violation] Forced reflow while executing JavaScript took 178ms
![image](https://user-images.githubusercontent.com/12039957/39213526-ad624698-47c6-11e8-80f4-f7fae4ff922f.png)
Sum of violations = 5812 ms

Again, status quo: With return to lo-res county bounds every time you zoom out, CA-AL-WY-NY-CA-AL-WY-NY:
[Violation] 'load' handler took 175ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 294ms
d3-4.11.0.min.js:2 [Violation] 'load' handler took 333ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 302ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 439ms
[Violation] Forced reflow while executing JavaScript took 181ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 273ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 449ms
[Violation] Forced reflow while executing JavaScript took 184ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 263ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 435ms
[Violation] Forced reflow while executing JavaScript took 177ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 258ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 432ms
[Violation] Forced reflow while executing JavaScript took 176ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 261ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 470ms
[Violation] Forced reflow while executing JavaScript took 188ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 254ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 437ms
[Violation] Forced reflow while executing JavaScript took 177ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 268ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 470ms
[Violation] Forced reflow while executing JavaScript took 192ms
d3-4.11.0.min.js:2 [Violation] 'click' handler took 280ms
d3-4.11.0.min.js:2 [Violation] 'requestAnimationFrame' handler took 446ms
[Violation] Forced reflow while executing JavaScript took 180ms
![image](https://user-images.githubusercontent.com/12039957/39213647-003fd40c-47c7-11e8-8a72-574a24880926.png)
Sum of violations = 7994 ms

As far as I can tell, not switching back to lo-res county bounds is a performance win.