### PR TITLE
Final rank 'em edits

### DIFF
--- a/js/rank_states_utils.js
+++ b/js/rank_states_utils.js
@@ -161,6 +161,11 @@ function rankEm(barData) {
         if (svgStates.select('#ranked-states-bars').selectAll('rect').filter('*:not(.locked-rank-bar)').empty()){
           d3.select('#rank-directions')
             .select('text').remove();
+          d3.select('#rank-explanation').selectAll('text')
+            .transition()
+            .delay(600)
+            .duration(600)
+            .style('opacity',1);
         }
   
       } else {
@@ -230,6 +235,22 @@ function rankEm(barData) {
       .classed('rankem-title', true)
       .attr('text-anchor','middle')
       .text('Drag a state over its matching bar');
+  
+  // add message about Idaho to conclude.  
+  var rankMsg = svgStates.append('g')
+    .attr('id', 'rank-explanation')
+    .attr('transform',"translate("+(rankSvg.width * 0.6)+",25)");
+  rankMsg
+    .append('text')
+      .classed('rankem-explanation', true)
+      .style('opacity', 0)
+      .text('Were you surprised by Idaho? Though it has a small');
+  rankMsg
+    .append('text')
+      .classed('rankem-explanation', true)
+      .style('opacity', 0)
+      .attr('dy', '1.2em')
+      .text('population, Idaho has a large agricultural industry.');
   
   var labelTextGroup = svgStates.append('g')
     .attr('id','rank-data-text')

--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -57,6 +57,13 @@
   font-family: 'Shadows Into Light';
 }
 
+.rankem-explanation{
+  fill: rgb(140,140,140);
+  font-size: 125%;
+  font-family: 'Shadows Into Light';
+  text-anchor: middle;
+}
+
 .open-bar-name {
   opacity: 0;
 }


### PR DESCRIPTION
I believe this checks all of the last boxes for #186.

- nicer text for displaying state and value
- change pointer to indicate draggable states (doesn't "grab" the state, but shows that it's interactive)
- state long names added
- units shown
- I _think_ it's taking advantage of Laura's nicer number formatting which happens in R before we even get it. They appear to match the numbers for state totals in the main fig.

![rank_em_edits](https://user-images.githubusercontent.com/13220910/39214791-482d3052-47db-11e8-9857-16ff9937b102.gif)
