### PR TITLE
disable text select within drag/drop fig

### DIFF
--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -3,6 +3,18 @@
   fill: transparent;
 }
 
+#rank-states-interactive text{
+  /* on mobile, clicking and holding the state for >1 sec caused fig text
+      to highlight and then when you tried to drag, you just selected more*/
+  -webkit-touch-callout: none; /* iOS Safari */
+  -webkit-user-select: none; /* Safari */
+  -khtml-user-select: none; /* Konqueror HTML */
+  -moz-user-select: none; /* Firefox */
+  -ms-user-select: none; /* Internet Explorer/Edge */
+  user-select: none; /* Non-prefixed version, currently
+                        supported by Chrome and Opera */
+}
+
 .state {
   fill: transparent;
   stroke: rgb(180,180,180);


### PR DESCRIPTION
@aappling-usgs noticed that when you tapped and held your finger down for more than one second and weren't right on a draggable state before starting to drag, it began to highlight the text rather than drag state around. This was very frustrating, so this PR turned off the ability to highlight (as in highlight to copy and paste) text within the rank 'em figure itself.