### PR TITLE
Cleaning up numbers

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -229,7 +229,8 @@ function fillMap() {
           'abrv': d.abrv,
           'STATE_NAME': d.STATE_NAME,
           'open': d.open,
-          'wu': d.use.filter(function(e) {return e.category === 'total';})[0].wateruse
+          'wu': d.use.filter(function(e) {return e.category === 'total';})[0].wateruse,
+          'fancynums': d.use.filter(function(e) {return e.category === 'total';})[0].fancynums
         };
         barData.push(x);
       });

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -311,7 +311,7 @@ function updateLegendTextToView() {
     waterUseViz.elements.buttonBox
       .selectAll('.category-amount')
       .data(state_data[0].use, function(d) { return d.category; })
-      .text(function(d) { return d.wateruse; });
+      .text(function(d) { return d.fancynums; });
       
   }
 

--- a/js/rank_states_utils.js
+++ b/js/rank_states_utils.js
@@ -51,7 +51,7 @@ function rankEm(barData) {
     }
     
     allText.select("#rank-value-text")
-      .text(data.wu);
+      .text(data.fancynums);
   };
   
   lockedBars

--- a/scripts/process/merge_centroids_wu.R
+++ b/scripts/process/merge_centroids_wu.R
@@ -13,11 +13,11 @@ process.merge_centroids_wu <- function(viz) {
     select(GEOID, STATE_ABBV, COUNTY, countypop:industrial) %>% 
     rowwise() %>% 
     mutate(other = total - sum(thermoelectric, publicsupply, irrigation, industrial)) %>%
-    mutate(total = signif(total, digits = 6),
-           thermoelectric = signif(thermoelectric, digits = 6),
-           irrigation = signif(irrigation, digits = 6),
-           publicsupply =  signif(publicsupply, digits = 6),
-           industrial = signif(industrial, digits = 6)) 
+    mutate(total = signif(total, digits = 3),
+           thermoelectric = signif(thermoelectric, digits = 3),
+           irrigation = signif(irrigation, digits = 3),
+           publicsupply =  signif(publicsupply, digits = 3),
+           industrial = signif(industrial, digits = 3)) 
   
   # add centroid coordinates to the WU data
   county_data <- county_data %>%

--- a/scripts/process/state_wu_data.R
+++ b/scripts/process/state_wu_data.R
@@ -13,12 +13,17 @@ process.state_wu_data <- function(viz) {
     
     wu_df_state <- wu_df %>%
       dplyr::filter(STATE == state) %>%
-      dplyr::summarise(total = signif(sum(total), digits = 6),
-                       thermoelectric = signif(sum(thermoelectric), digits = 6),
-                       publicsupply = signif(sum(publicsupply), digits = 6),
-                       irrigation = signif(sum(irrigation), digits = 6),
-                       industrial = signif(sum(industrial), digits = 6)) %>%
-      tidyr::gather(category, wateruse)
+      dplyr::summarise(total = signif(sum(total), digits = 3),
+                       thermoelectric = signif(sum(thermoelectric), digits = 3),
+                       publicsupply = signif(sum(publicsupply), digits = 3),
+                       irrigation = signif(sum(irrigation), digits = 3),
+                       industrial = signif(sum(industrial), digits = 3)) %>%
+      tidyr::gather(category, wateruse) %>%
+      mutate(fancynums = ifelse(wateruse>2,
+                                format(round(wateruse), big.mark=",", scientific=FALSE),
+                                format(wateruse, big.mark=",", scientific=FALSE)))
+    
+    wu_df_state$fancynums <- gsub(" ","",wu_df_state$fancynums)
     
     state_data[[i]] <- list(abrv = state,
                            open = state %in% viz[["process_args"]][["drag_states"]],

--- a/scripts/process/summarize_wu_data.R
+++ b/scripts/process/summarize_wu_data.R
@@ -20,7 +20,7 @@ process.summarize_wu_data <- function(viz) {
   wu_df_national_transf <- tidyr::gather(wu_df_national, key = "category", value = "wateruse")
 
   wu_df_national_transf$fancynums <- format(round(wu_df_national_transf$wateruse), big.mark=",", scientific=FALSE)
-  
+  wu_df_national_transf$fancynums <- gsub(" ","",wu_df_national_transf$fancynums)
   
   jsonlite::write_json(wu_df_national_transf, viz[["location"]])
 }


### PR DESCRIPTION
States now have commas:

![image](https://user-images.githubusercontent.com/1105215/39369263-6e37aaac-4a01-11e8-9001-c1348d0d5e62.png)

![image](https://user-images.githubusercontent.com/1105215/39369302-8a816ab8-4a01-11e8-9d6f-a754a48a6c68.png)

Any state less than 2 gets some sigfigs:
![image](https://user-images.githubusercontent.com/1105215/39369354-aa3f23ae-4a01-11e8-8846-7c7176c4f5fd.png)

There are now 3 significant figures for the county data, but no commas on that.