### PR TITLE
Circles as paths

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -180,10 +180,10 @@ function fillMap() {
   
   // add the circles
   // CIRCLES-AS-CIRCLES
-  addCircles(countyCentroids);
+  //addCircles(countyCentroids);
   // CIRCLES-AS-PATHS
-  /*var circlesPaths = prepareCirclePaths(categories, countyCentroids);
-  addCircles(circlesPaths);*/
+  var circlesPaths = prepareCirclePaths(categories, countyCentroids);
+  addCircles(circlesPaths);
   updateCircleCategory(activeCategory);
   
   // manipulate dropdowns

--- a/js/circles.js
+++ b/js/circles.js
@@ -100,17 +100,17 @@ function updateCircleSize(category, view) {
     .attr("r", function(d) { return scaleCircles(d[[category]]); });
   */
   // CIRCLES-AS-PATHS
-  d3.selectAll("#wu-path")
-  .transition().duration(600)
-  .attr("d", function(d) { 
-    if(view === 'USA') {
-      // don't recalculate circle paths on zoom out, just reapply data attached
-      return d[[category]]; 
-    } else {
-      // when zooming in, data attached won't change but values of radius will
-      // based on new domain for scaleCircles (applied in createCirclePath)
-      return createCirclePath(category, countyCentroids); 
-    }
+  d3.select('#wu-path')
+    .transition().duration(600)
+    .attr("d", function(d) { 
+      if(view === 'USA') {
+        // don't recalculate circle paths on zoom out, just reapply data attached
+        return d[[category]]; 
+      } else {
+        // when zooming in, data attached won't change but values of radius will
+        // based on new domain for scaleCircles (applied in createCirclePath)
+        return createCirclePath(category, countyCentroids); 
+      }
   });
  
 }

--- a/js/circles.js
+++ b/js/circles.js
@@ -1,5 +1,5 @@
 // CIRCLES-AS-PATHS
-/*function prepareCirclePaths(categories, countyCentroids) {
+function prepareCirclePaths(categories, countyCentroids) {
   
   // uses globals scaleCircles, projectX, projectY
   
@@ -27,12 +27,13 @@
 
 }
 function addCircles(circlesPaths) {
-*/
-function addCircles(countyCentroids) {
+
+//function addCircles(countyCentroids) {
   
   // uses globals map
   
   // CIRCLES-AS-CIRCLES
+  /*
   map.selectAll('g#wu-circles').selectAll('.wu-circle')
     .data(countyCentroids)
     .enter()
@@ -44,9 +45,9 @@ function addCircles(countyCentroids) {
     .attr("cy", function(d) { return projectY([d.lon, d.lat]); })
     .attr("r", 0)
     .style("fill", "transparent"); // start transparent & updateCircleColor will transition to color
+  */
   
   // CIRCLES-AS-PATHS
-  /*
   map.selectAll('g#wu-circles')
     .datum(circlesPaths)
     .append('path')
@@ -54,7 +55,6 @@ function addCircles(countyCentroids) {
     .attr('id', 'wu-path')
     .style('stroke','none')
     .style('fill', 'none'); // start transparent & updateCircleColor will transition to color
-    */
     
   map.selectAll('g#wu-circles')
     .append('circle')
@@ -67,27 +67,36 @@ function addCircles(countyCentroids) {
 function updateCircleCategory(category) {
   
   // grow circles to appropriate size && changes color
+  /*
   d3.selectAll("circle.wu-basic")
     .transition().duration(1000)
     .attr("r", function(d) { return scaleCircles(d[[category]]); })
     .style("fill", categoryToColor(category))
     .style("stroke", categoryToColor(category, stroke=true));
+  */
   
   // CIRCLES-AS-PATHS
-  /*// grow circles to appropriate size
+  // grow circles to appropriate size
   d3.select('#wu-path')
     .transition().duration(1000)
     .attr("d", function(d) { return d[[category]]; })
     .style("stroke", categoryToColor(category))
-    .style("fill", categoryToColor(category));*/
+    .style("fill", categoryToColor(category));
 
 }
 
 function updateCircleSize(category) {
   // makes circles the appropriate size
+  /* 
+  // CIRCLES-AS-CIRCLES
   d3.selectAll("circle.wu-basic")
     .transition().duration(600)
     .attr("r", function(d) { return scaleCircles(d[[category]]); });
+  */
+  // CIRCLES-AS-PATHS
+  d3.selectAll("#wu-path")
+    .transition().duration(600)
+    .attr("d", function(d) { return d[[category]]; });
 
 }
 

--- a/js/circles.js
+++ b/js/circles.js
@@ -1,31 +1,37 @@
 // CIRCLES-AS-PATHS
-function prepareCirclePaths(categories, countyCentroids) {
+function createCirclePath(cat, centroidData) {
+  // create an array of 1-circle paths of the form 'Mx y a r r 0 1 1 0 0.01',
+  // where x is the leftmost point (cx - r), y is cy, and r is radius
+  var pathArray = [];
+  centroidData.forEach(function(d) {
+    var radius = scaleCircles(d[[cat]]);
+    var path = 'M' + (projectX([d.lon, d.lat]) - radius) + ' ' + 
+      projectY([d.lon, d.lat]) +
+      ' a ' + radius + ' ' + radius +
+      ' 0 1 1 0 0.01z';
+    pathArray.push(path);
+  });
+
+  // concatenate into a single string for all circles in the category
+  var fullPath = pathArray.join(sep=' ');
+  
+  return fullPath;
+}
+
+function prepareCirclePaths(categories, centroidData) {
   
   // uses globals scaleCircles, projectX, projectY
   
   // create an object literal of many-circle paths, one per category
   var catPaths = {};
   categories.forEach(function(cat) {
-    // create an array of 1-circle paths of the form 'Mx y a r r 0 1 1 0 0.01',
-    // where x is the leftmost point (cx - r), y is cy, and r is radius
-    var pathArray = [];
-    countyCentroids.forEach(function(d) {
-      var radius = scaleCircles(d[[cat]]);
-      var path = 'M' + (projectX([d.lon, d.lat]) - radius) + ' ' + projectY([d.lon, d.lat]) +
-        ' a ' + radius + ' ' + radius +
-        ' 0 1 1 0 0.01z';
-      pathArray.push(path);
-    });
-  
-    // concatenate into a single string for all circles in the category
-    var fullPath = pathArray.join(sep=' ');
-    
-    catPaths[[cat]] = fullPath;
+    catPaths[[cat]] = createCirclePath(cat, centroidData);
   });
   
   return catPaths;
 
 }
+
 function addCircles(circlesPaths) {
 
 //function addCircles(countyCentroids) {
@@ -95,9 +101,9 @@ function updateCircleSize(category) {
   */
   // CIRCLES-AS-PATHS
   d3.selectAll("#wu-path")
-    .transition().duration(600)
+  .transition().duration(600)
     .attr("d", function(d) { return d[[category]]; });
-
+ 
 }
 
 function highlightCircle(countyDatum, category) {

--- a/js/circles.js
+++ b/js/circles.js
@@ -85,7 +85,15 @@ function updateCircleCategory(category) {
   // grow circles to appropriate size
   d3.select('#wu-path')
     .transition().duration(1000)
-    .attr("d", function(d) { return d[[category]]; })
+    .attr("d", function(d) { 
+      if(activeView == 'USA') {
+        return d[[category]];
+      } else {
+        // recalculate the new circle path size for this new category
+        // updateCircleSize only updates the current category.
+        return createCirclePath(category, countyCentroids);
+      } 
+    })
     .style("stroke", categoryToColor(category))
     .style("fill", categoryToColor(category));
 

--- a/js/circles.js
+++ b/js/circles.js
@@ -91,7 +91,7 @@ function updateCircleCategory(category) {
 
 }
 
-function updateCircleSize(category) {
+function updateCircleSize(category, view) {
   // makes circles the appropriate size
   /* 
   // CIRCLES-AS-CIRCLES
@@ -102,7 +102,16 @@ function updateCircleSize(category) {
   // CIRCLES-AS-PATHS
   d3.selectAll("#wu-path")
   .transition().duration(600)
-    .attr("d", function(d) { return d[[category]]; });
+  .attr("d", function(d) { 
+    if(view === 'USA') {
+      // don't recalculate circle paths on zoom out, just reapply data attached
+      return d[[category]]; 
+    } else {
+      // when zooming in, data attached won't change but values of radius will
+      // based on new domain for scaleCircles (applied in createCirclePath)
+      return createCirclePath(category, countyCentroids); 
+    }
+  });
  
 }
 

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -168,7 +168,7 @@ function applyZoomAndStyle(newView) {
   if(scaleCircles.domain() !== newScaling) {
     // only change circle scale if it's different
     scaleCircles.domain(newScaling);
-    updateCircleSize(activeCategory);
+    updateCircleSize(activeCategory, activeView);
   }
 
   // reset counties each time a zoom changes


### PR DESCRIPTION
Fixes #119. This all worked perfectly fine for me. I just uncommented the code that Alison had written before and then added the tricks for rescaling the radii on zoom. I tried to limit the number of times the paths were being recalculated, so I never overwrote the national view radii. I only recalculated the paths for the current category when you zoom, or if you are not in the national view when you change categories. I don't think it takes much to recalculate, but just wanted to limit it as much as possible. 

I did look into the weird flashing that David mentioned on Slack (and Laura has mentioned before). Comments captured here #271 (I don't want this issue to be held up by that discussion).

I was not able to locally test this on mobile. Need a mac to do that.