### PR TITLE
turnoff overflow on IE

### DIFF
--- a/layout/css/map.css
+++ b/layout/css/map.css
@@ -1,4 +1,9 @@
 
+svg {
+  /* needed to stop IE from letting zoom show circles everywhere */
+  overflow:hidden;
+}
+
 #map-background {
   fill: transparent;
 }


### PR DESCRIPTION
This wasn't created into a github issue, but I did a quick look at why this happened while getting my lunch and it's because IE is the only browser that doesn't automatically set overflow to hidden. This did not seem to break anything on any other browser. 

Here's the issue I followed: https://stackoverflow.com/questions/27985171/d3-js-zoom-with-nested-svg-breaks-viewport-in-internet-explorer

Before:
![ie_overflow](https://user-images.githubusercontent.com/13220910/39376745-5951ea5a-4a18-11e8-9b3f-a347ae294400.gif)

After:
![ie_overflow_fixed](https://user-images.githubusercontent.com/13220910/39376749-5b86d678-4a18-11e8-9a8a-cd97ad016b8a.gif)
