### PR TITLE
move state and national summary json into queue

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -95,12 +95,16 @@ if(waterUseViz.interactionMode === 'tap') {
     .defer(d3.json, "data/state_boundaries_mobile.json")
     .defer(d3.tsv, "data/county_centroids_wu.tsv")
     .defer(d3.json, "data/wu_data_15_range.json")
+    .defer(d3.json, "data/wu_data_15_sum.json")
+    .defer(d3.json, "data/wu_state_data.json")
     .await(fillMap);
 } else {
   d3.queue()
     .defer(d3.json, "data/state_boundaries_USA.json")
     .defer(d3.tsv, "data/county_centroids_wu.tsv")
     .defer(d3.json, "data/wu_data_15_range.json")
+    .defer(d3.json, "data/wu_data_15_sum.json")
+    .defer(d3.json, "data/wu_state_data.json")
     .await(fillMap);
 }
 
@@ -179,6 +183,12 @@ function fillMap() {
   // set up scaling for circles at national level
   waterUseViz.nationalRange = arguments[3];
   
+  // cache data for dotmap and update legend if we're in national view
+  waterUseViz.nationalData = arguments[4];
+  
+  // cache data for dotmap and update legend if we're in state view
+  waterUseViz.stateData = arguments[5];
+  
   // update circle scale with data
   scaleCircles = scaleCircles
     .domain(waterUseViz.nationalRange);
@@ -205,6 +215,9 @@ function fillMap() {
   updateViewSelectorOptions(activeView, stateBoundsUSA);
   addZoomOutButton(activeView);
   
+  // update the legend values and text
+  updateLegendTextToView();
+  
   // load county data, add and update county polygons.
   // it's OK if it's not done right away; it should be loaded by the time anyone tries to hover!
   // and it doesn't need to be done at all for mobile
@@ -215,42 +228,26 @@ function fillMap() {
     // if and when the user zooms out from a state, updateCounties won't try to load the low-res data
     countyBoundsUSA = true;
   }
-  
-  // Read national data and add it to figure
-  d3.json("data/wu_data_15_sum.json", function(error, data) {
-    if (error) throw error;
     
-    // cache data for dotmap and update legend if we're in national view
-    waterUseViz.nationalData = data;
-    if(activeView === 'USA') updateLegendTextToView();
-    // create big pie figure (uses nationalData)
-    if(!waterUseViz.isEmbed) loadPie();
-    
+  // format data for rankEm
+  var  barData = [];
+  waterUseViz.stateData.forEach(function(d) {
+      var x = {
+        'abrv': d.abrv,
+        'STATE_NAME': d.STATE_NAME,
+        'open': d.open,
+        'wu': d.use.filter(function(e) {return e.category === 'total';})[0].wateruse,
+        'fancynums': d.use.filter(function(e) {return e.category === 'total';})[0].fancynums
+      };
+      barData.push(x);
   });
   
-  // Read state data and add it to figure
-  d3.json("data/wu_state_data.json", function(error, data) {
-    if (error) throw error;
-    
-    // cache data for dotmap and update legend if we're in state view
-    waterUseViz.stateData = data;
-    if(activeView !== 'USA') updateLegendTextToView();
-    
-    
-    // format data for rankEm and create rankEm figure
-    var  barData = [];
-    waterUseViz.stateData.forEach(function(d) {
-        var x = {
-          'abrv': d.abrv,
-          'STATE_NAME': d.STATE_NAME,
-          'open': d.open,
-          'wu': d.use.filter(function(e) {return e.category === 'total';})[0].wateruse,
-          'fancynums': d.use.filter(function(e) {return e.category === 'total';})[0].fancynums
-        };
-        barData.push(x);
-      });
-    if(!waterUseViz.isEmbed) rankEm(barData);
-  });
+  // create big pie figure (uses waterUseViz.nationalData)
+  if(!waterUseViz.isEmbed) loadPie();
+  
+  // create rankEm figure  
+  if(!waterUseViz.isEmbed) rankEm(barData);
+
 }
 
 function loadInitialCounties() {

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -90,23 +90,18 @@ var tooltipDiv = d3.select("body").append("div")
   .classed("tooltip hidden", true);
 
 // Read data and add to map
+var dataQueue = d3.queue();
 if(waterUseViz.interactionMode === 'tap') {
-  d3.queue()
-    .defer(d3.json, "data/state_boundaries_mobile.json")
-    .defer(d3.tsv, "data/county_centroids_wu.tsv")
-    .defer(d3.json, "data/wu_data_15_range.json")
-    .defer(d3.json, "data/wu_data_15_sum.json")
-    .defer(d3.json, "data/wu_state_data.json")
-    .await(fillMap);
+  dataQueue.defer(d3.json, "data/state_boundaries_mobile.json");
 } else {
-  d3.queue()
-    .defer(d3.json, "data/state_boundaries_USA.json")
-    .defer(d3.tsv, "data/county_centroids_wu.tsv")
-    .defer(d3.json, "data/wu_data_15_range.json")
-    .defer(d3.json, "data/wu_data_15_sum.json")
-    .defer(d3.json, "data/wu_state_data.json")
-    .await(fillMap);
+  dataQueue.defer(d3.json, "data/state_boundaries_USA.json");
 }
+dataQueue
+  .defer(d3.tsv, "data/county_centroids_wu.tsv")
+  .defer(d3.json, "data/wu_data_15_range.json")
+  .defer(d3.json, "data/wu_data_15_sum.json")
+  .defer(d3.json, "data/wu_state_data.json")
+  .await(fillMap);
 
 /** Functions **/
 

--- a/viz.yaml
+++ b/viz.yaml
@@ -246,6 +246,8 @@ publish:
       map_states: map_states
       map_counties: "map_counties"
       dropdown_selector: "dropdown_selector"
+      national_pie: "national_pie"
+      rank_states_utils: "rank_states_utils"
       state_boundaries_USA: state_boundaries_USA_topojson
       state_boundaries_zoom: state_boundaries_zoom_topojson
       state_boundaries_mobile: state_boundaries_mobile_topojson
@@ -258,7 +260,8 @@ publish:
     context:
       resources: ["lib_d3_js", "topojson", "header_css", "content_css", "footer_css", "socialCSS","vizlab-favicon",
                   "map_css", "custom_css", "hashes", "projection", "styles", "buttons", "resize", "map_utils",
-                  "map_states", "map_counties", "watermark_utils", "map_circles", "dropdown_selector", "modernizr"]
+                  "map_states", "map_counties", "watermark_utils", "map_circles", "dropdown_selector", "modernizr",
+                  "national_pie", "rank_states_utils"]
       sections: ["social", "mobile_map_ui", "map_section", "wu_story"] # adding header and footer here, doubled each on the page
       thumbnails: 
         twitter: thumb-facebook


### PR DESCRIPTION
There are issues with the order in which things are located that has been causing errors, see https://github.com/USGS-VIZLAB/water-use-15/issues/268#issuecomment-385294530. Since these files are small and won't significantly impact the initial load time, I moved them into the overall queue and then rearranged the queue from what is was in #285 so that the `if`-else statement didn't repeat file paths. I no longer see the error mentioned in #268. 

This also required me to add `national_pie` and `rank_states_utils` as resources to the main fig since `loadPie` and `rankEm` are called in `fillMap`. I think we were lucking out that they were inside `d3.json` calls which allowed enough time for those functions to become available when their resources were loaded later down the page.