### PR TITLE
Revert paths again

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -200,10 +200,10 @@ function fillMap() {
   
   // add the circles
   // CIRCLES-AS-CIRCLES
-  //addCircles(countyCentroids);
+  addCircles(countyCentroids);
   // CIRCLES-AS-PATHS
-  var circlesPaths = prepareCirclePaths(categories, countyCentroids);
-  addCircles(circlesPaths);
+  /*var circlesPaths = prepareCirclePaths(categories, countyCentroids);
+  addCircles(circlesPaths);*/
   updateCircleCategory(activeCategory);
   
   // manipulate dropdowns

--- a/js/circles.js
+++ b/js/circles.js
@@ -1,7 +1,10 @@
 // CIRCLES-AS-PATHS
+/*
 function createCirclePath(cat, centroidData, splitIndex) {
   // create an array of 1-circle paths of the form 'Mx y a r r 0 1 1 0 0.01',
   // where x is the leftmost point (cx - r), y is cy, and r is radius
+  
+  // uses globals scaleCircles, projectX, projectY
   
   var splitThreshold = Math.round(centroidData.length/2);
   
@@ -27,8 +30,6 @@ function createCirclePath(cat, centroidData, splitIndex) {
 
 function prepareCirclePaths(categories, centroidData) {
   
-  // uses globals scaleCircles, projectX, projectY
-  
   // create an object literal of many-circle paths, one per category
   var catPaths = {},
       catPaths2 = {};
@@ -42,13 +43,13 @@ function prepareCirclePaths(categories, centroidData) {
 }
 
 function addCircles(circlesPaths) {
+*/
 
-//function addCircles(countyCentroids) {
+function addCircles(countyCentroids) {
   
   // uses globals map
   
   // CIRCLES-AS-CIRCLES
-  /*
   map.selectAll('g#wu-circles').selectAll('.wu-circle')
     .data(countyCentroids)
     .enter()
@@ -60,9 +61,9 @@ function addCircles(circlesPaths) {
     .attr("cy", function(d) { return projectY([d.lon, d.lat]); })
     .attr("r", 0)
     .style("fill", "transparent"); // start transparent & updateCircleColor will transition to color
-  */
   
   // CIRCLES-AS-PATHS
+  /*
   map.selectAll('g#wu-circles')
     .selectAll('.wu-path')
     .data(circlesPaths)
@@ -75,7 +76,8 @@ function addCircles(circlesPaths) {
     })
     .style('stroke','none')
     .style('fill', 'none'); // start transparent & updateCircleColor will transition to color
-    
+  */
+
   map.selectAll('g#wu-circles')
     .append('circle')
     .classed('wu-circle', true)
@@ -94,15 +96,15 @@ function updateCircleCategory(category) {
     transitionTime = 0;
   }
     
-  /*
+  // CIRCLES-AS-CIRCLES
   d3.selectAll("circle.wu-basic")
     .transition().duration(1000)
     .attr("r", function(d) { return scaleCircles(d[[category]]); })
-    .style("fill", categoryToColor(category))
-    .style("stroke", categoryToColor(category, stroke=true));
-  */
+    .style("stroke", categoryToColor(category))
+    .style("fill", categoryToColor(category));
   
   // CIRCLES-AS-PATHS
+  /*
   // grow circles to appropriate size
   d3.select('.wu-path')
     .transition().duration(transitionTime)
@@ -118,6 +120,7 @@ function updateCircleCategory(category) {
     })
     .style("stroke", categoryToColor(category))
     .style("fill", categoryToColor(category));
+  */
 
 }
 
@@ -131,15 +134,14 @@ function updateCircleSize(category, view) {
     transitionTime = 0;
   }
   
-  /* 
   // CIRCLES-AS-CIRCLES
   d3.selectAll("circle.wu-basic")
     .transition()
     .duration(transitionTime)
     .attr("r", function(d) { return scaleCircles(d[[category]]); });
-  */
   
   // CIRCLES-AS-PATHS
+  /* 
   d3.select('.wu-path')
     .transition().duration(transitionTime)
     .attr("d", function(d, i) { 
@@ -153,6 +155,7 @@ function updateCircleSize(category, view) {
         return createCirclePath(category, countyCentroids, i); 
       }
   });
+  */
 }
 
 function highlightCircle(countyDatum, category) {

--- a/js/circles.js
+++ b/js/circles.js
@@ -60,6 +60,7 @@ function addCircles(countyCentroids) {
     .attr("cx", function(d) { return projectX([d.lon, d.lat]); })
     .attr("cy", function(d) { return projectY([d.lon, d.lat]); })
     .attr("r", 0)
+    .style("stroke", "none")
     .style("fill", "transparent"); // start transparent & updateCircleColor will transition to color
   
   // CIRCLES-AS-PATHS
@@ -100,7 +101,7 @@ function updateCircleCategory(category) {
   d3.selectAll("circle.wu-basic")
     .transition().duration(1000)
     .attr("r", function(d) { return scaleCircles(d[[category]]); })
-    .style("stroke", categoryToColor(category))
+    //.style("stroke", categoryToColor(category))
     .style("fill", categoryToColor(category));
   
   // CIRCLES-AS-PATHS

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -206,11 +206,11 @@ function applyZoomAndStyle(newView, doTransition) {
     emphasizeCounty(statecounties);
     backgroundState(otherstates, scale = zoom.s);
     foregroundState(thisstate, scale = zoom.s);
-    scaleCircleStroke(wucircles, scale = zoom.s);
+    //scaleCircleStroke(wucircles, scale = zoom.s);
     
   } else {
     // only reset stroke when zooming back out
-    resetCircleStroke();
+    //resetCircleStroke();
   }
   
   var allcounties = d3.selectAll('.county');

--- a/js/styles.js
+++ b/js/styles.js
@@ -114,6 +114,7 @@ function unhighlightCounty() {
     .classed("highlighted-county", false);
 }
 
+/*
 function scaleCircleStroke(selection, scale) {
   selection
     .style("stroke-width", 2/scale+"px");
@@ -126,3 +127,4 @@ function resetCircleStroke() {
     .delay(500) // delay until > 1/2 way through zoom out
     .style("stroke-width", null);
 }
+*/


### PR DESCRIPTION
Headed back to circles as circles while reviewers are looking and until we can get circles as paths working everywhere.

Effectively reverting https://github.com/USGS-VIZLAB/water-use-15/pull/272/files and https://github.com/USGS-VIZLAB/water-use-15/pull/282/files.

Sticking with most recent decision to not have strokes on circles (https://github.com/USGS-VIZLAB/water-use-15/issues/271).