### PR TITLE
welcome back circles-as-paths + fix missing ones

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -200,10 +200,10 @@ function fillMap() {
   
   // add the circles
   // CIRCLES-AS-CIRCLES
-  addCircles(countyCentroids);
+  /*addCircles(countyCentroids);*/
   // CIRCLES-AS-PATHS
-  /*var circlesPaths = prepareCirclePaths(categories, countyCentroids);
-  addCircles(circlesPaths);*/
+  var circlesPaths = prepareCirclePaths(categories, countyCentroids);
+  addCircles(circlesPaths);
   updateCircleCategory(activeCategory);
   
   // manipulate dropdowns

--- a/js/circles.js
+++ b/js/circles.js
@@ -111,7 +111,7 @@ function updateCircleCategory(category) {
   // CIRCLES-AS-PATHS
   
   // grow circles to appropriate size
-  d3.select('.wu-path')
+  d3.selectAll('.wu-path')
     .transition().duration(transitionTime)
     .attr("d", function(d, i) { 
       if(activeView == 'USA') {
@@ -149,7 +149,7 @@ function updateCircleSize(category, view) {
   
   // CIRCLES-AS-PATHS
    
-  d3.select('.wu-path')
+  d3.selectAll('.wu-path')
     .transition().duration(transitionTime)
     .attr("d", function(d, i) { 
       if(view === 'USA') {

--- a/js/circles.js
+++ b/js/circles.js
@@ -123,7 +123,7 @@ function updateCircleCategory(category) {
         return createCirclePath(category, countyCentroids, i);
       } 
     })
-    .style("stroke", categoryToColor(category))
+    //.style("stroke", categoryToColor(category))
     .style("fill", categoryToColor(category));
   
 

--- a/js/circles.js
+++ b/js/circles.js
@@ -1,5 +1,5 @@
 // CIRCLES-AS-PATHS
-/*
+
 function createCirclePath(cat, centroidData, splitIndex) {
   // create an array of 1-circle paths of the form 'Mx y a r r 0 1 1 0 0.01',
   // where x is the leftmost point (cx - r), y is cy, and r is radius
@@ -43,13 +43,14 @@ function prepareCirclePaths(categories, centroidData) {
 }
 
 function addCircles(circlesPaths) {
-*/
 
-function addCircles(countyCentroids) {
+
+//function addCircles(countyCentroids) {
   
   // uses globals map
   
   // CIRCLES-AS-CIRCLES
+  /*
   map.selectAll('g#wu-circles').selectAll('.wu-circle')
     .data(countyCentroids)
     .enter()
@@ -62,9 +63,10 @@ function addCircles(countyCentroids) {
     .attr("r", 0)
     .style("stroke", "none")
     .style("fill", "transparent"); // start transparent & updateCircleColor will transition to color
+  */
   
   // CIRCLES-AS-PATHS
-  /*
+  
   map.selectAll('g#wu-circles')
     .selectAll('.wu-path')
     .data(circlesPaths)
@@ -77,7 +79,7 @@ function addCircles(countyCentroids) {
     })
     .style('stroke','none')
     .style('fill', 'none'); // start transparent & updateCircleColor will transition to color
-  */
+  
 
   map.selectAll('g#wu-circles')
     .append('circle')
@@ -98,14 +100,16 @@ function updateCircleCategory(category) {
   }
     
   // CIRCLES-AS-CIRCLES
+  /*
   d3.selectAll("circle.wu-basic")
     .transition().duration(1000)
     .attr("r", function(d) { return scaleCircles(d[[category]]); })
     //.style("stroke", categoryToColor(category))
     .style("fill", categoryToColor(category));
+  */
   
   // CIRCLES-AS-PATHS
-  /*
+  
   // grow circles to appropriate size
   d3.select('.wu-path')
     .transition().duration(transitionTime)
@@ -121,7 +125,7 @@ function updateCircleCategory(category) {
     })
     .style("stroke", categoryToColor(category))
     .style("fill", categoryToColor(category));
-  */
+  
 
 }
 
@@ -136,13 +140,15 @@ function updateCircleSize(category, view) {
   }
   
   // CIRCLES-AS-CIRCLES
+  /*
   d3.selectAll("circle.wu-basic")
     .transition()
     .duration(transitionTime)
     .attr("r", function(d) { return scaleCircles(d[[category]]); });
+  */
   
   // CIRCLES-AS-PATHS
-  /* 
+   
   d3.select('.wu-path')
     .transition().duration(transitionTime)
     .attr("d", function(d, i) { 
@@ -156,7 +162,7 @@ function updateCircleSize(category, view) {
         return createCirclePath(category, countyCentroids, i); 
       }
   });
-  */
+  
 }
 
 function highlightCircle(countyDatum, category) {


### PR DESCRIPTION
As noted in https://github.com/USGS-VIZLAB/water-use-15/issues/119#issuecomment-385260864, there were some counties that were missing. This was because of using `.select('.wu-path')` instead of `.selectAll('.wu-path')` by mistake. So, it was only adding data for the first half of counties and not the second. This also follows #289 and removes stroke for circles as paths.

![image](https://user-images.githubusercontent.com/13220910/39447073-38ea87ac-4c86-11e8-9b6b-d80b4df51667.png)
