### PR TITLE
fixes #291

### DIFF
--- a/scripts/preprocess/process_zip_to_shp.R
+++ b/scripts/preprocess/process_zip_to_shp.R
@@ -24,15 +24,17 @@ read_shp_zip <- function(zipfile) {
   return(data_out)  
 }
 
-scale_shifted_shps <- function(sp, PR_scale = 3){
+#' @param fips a character vector of fips to be scaled
+#' @param scale a scale factor to apply to fips
+scale_shifted_shps <- function(sp, fips, scale){
   
-  pr_sp <- sp[(sp@data$STATEFP %in% c('72','78')), ]
-  pr_cent <- rgeos::gCentroid(pr_sp, byid=F)@coords
-  pr_scale <- max(apply(bbox(pr_sp), 1, diff)) * PR_scale
-  obj <- maptools::elide(pr_sp, scale=pr_scale, center=pr_cent, bb = bbox(pr_sp))
+  toshift_sp <- sp[sp@data$STATEFP %in% fips, ]
+  toshift_cent <- rgeos::gCentroid(toshift_sp, byid=F)@coords
+  toshift_scale <- max(apply(bbox(toshift_sp), 1, diff)) * scale
+  obj <- maptools::elide(toshift_sp, scale=toshift_scale, center=toshift_cent, bb = bbox(toshift_sp))
   new_cent <- rgeos::gCentroid(obj, byid=FALSE)@coords
-  obj <- maptools::elide(obj, shift=c(pr_cent-new_cent))
+  obj <- maptools::elide(obj, shift=c(toshift_cent-new_cent))
   proj4string(obj) <- proj4string(sp)
-  sp_out <- rbind(sp[!(sp@data$STATEFP %in% c('72','78')), ], obj)
+  sp_out <- rbind(sp[!(sp@data$STATEFP %in% fips), ], obj)
   return(sp_out)
 }

--- a/scripts/preprocess/process_zip_to_shp.R
+++ b/scripts/preprocess/process_zip_to_shp.R
@@ -24,8 +24,10 @@ read_shp_zip <- function(zipfile) {
   return(data_out)  
 }
 
+#' @param sp the full spatial object to be altered, w/ STATEFP attribute
 #' @param fips a character vector of fips to be scaled
 #' @param scale a scale factor to apply to fips
+#' @return an `sp` similar to the input, but with the specified fips scaled according to `scale` parameter
 scale_shifted_shps <- function(sp, fips, scale){
   
   toshift_sp <- sp[sp@data$STATEFP %in% fips, ]


### PR DESCRIPTION
This is clean up for #291 and doesn't alter anything now (it isn't used). 

The syntax for using this (PR example):
```yaml
  county_boundaries_PR_shifted:
    command: scale_shifted_shps(county_boundaries_census_sp, fips = I(c('72','78')), scale = I(3))
```

The reason this exists is that we simplify all of the counties and state borders using lat/lon geometries from their actual location, then move some and scale some of them up or down for display (AK and PR notably). So, we are oversimplifying PR relative to its final display (it gets scaled up) and undersimplifying AK relative to its final display (it gets scaled down) when trying to hit the sweet spot with scaling factors so that the 1) file size isn't too big, 2) we don't simplify so much that we drop counties/islands. 

This potential solution may be useful in the future but is probably not now. There is a lot of challenging things going on in the [custom projection](https://github.com/USGS-VIZLAB/water-use-15/blob/master/js/custom_projection.js) js code that I couldn't wrap my head around, but the hope is we can pre-scale and then be able to take the scaling out of js (see [here](https://github.com/USGS-VIZLAB/water-use-15/blob/master/js/custom_projection.js#L104) ) or ...maybe both pre-scale and pre-shift sometime further down the road. 

red is original and black is scaled: 
![image](https://user-images.githubusercontent.com/2349007/39449314-53ff645c-4c8d-11e8-95fb-bbb5d6976f16.png)

![image](https://user-images.githubusercontent.com/2349007/39449388-81aade4a-4c8d-11e8-846d-3374a258f724.png)

I don't think this code fully works with the AK islands that are further west than -180° longitude, but I am not noodling around with that right now because I don't think this is going to be used in the near-term. 
