### PR TITLE
Small legend positioning adjustments

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -10,7 +10,8 @@ var waterUseViz = {
       widthDesktop: 250,
       heightDesktop: 275,
       width: null,
-      height: null
+      height: null,
+      titlesHeight: null
     },
     svg: {
       width: null,

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -133,12 +133,12 @@ function resizeButtons() {
   // category labels are left aligned, nudged a little over from the rectangle's left edge.
   // category water use amounts are right aligned, nudged a little over from the rectangle's right edge.
   waterUseViz.elements.buttonBox.selectAll('.button .category-label')
-    .attr('x', +activeButton.attr('x') + activeButton.attr('width') * 0.02)
+    .attr('x', +activeButton.attr('x') + activeButton.attr('width') * 0.03)
     .attr('y', function(d) {
       return buttonY.bandwidth()/2;
     });
   waterUseViz.elements.buttonBox.selectAll('.button .category-amount')
-    .attr('x', waterUseViz.dims.buttonBox.width * 0.05 + activeButton.attr('width') * 0.98)
+    .attr('x', waterUseViz.dims.buttonBox.width * 0.05 + activeButton.attr('width') * 0.97)
     .attr('y', function(d) {
       return buttonY.bandwidth()/2;
     });

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -73,7 +73,7 @@ function addButtons() {
 function resizeButtons() {
   
    // reserve the top band for titles
-   titlesHeight = waterUseViz.dims.buttonBox.height * 0.22;
+   titlesHeight = waterUseViz.dims.buttonBox.titlesHeight;
   
   // recompute the button heights and positions for the new buttonBox width
   var buttonY = d3.scaleBand()

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -133,12 +133,12 @@ function resizeButtons() {
   // category labels are left aligned, nudged a little over from the rectangle's left edge.
   // category water use amounts are right aligned, nudged a little over from the rectangle's right edge.
   waterUseViz.elements.buttonBox.selectAll('.button .category-label')
-    .attr('x', +activeButton.attr('x') + activeButton.attr('width') * 0.05)
+    .attr('x', +activeButton.attr('x') + activeButton.attr('width') * 0.02)
     .attr('y', function(d) {
       return buttonY.bandwidth()/2;
     });
   waterUseViz.elements.buttonBox.selectAll('.button .category-amount')
-    .attr('x', waterUseViz.dims.buttonBox.width * 0.05 + activeButton.attr('width') * 0.95)
+    .attr('x', waterUseViz.dims.buttonBox.width * 0.05 + activeButton.attr('width') * 0.98)
     .attr('y', function(d) {
       return buttonY.bandwidth()/2;
     });

--- a/js/resize.js
+++ b/js/resize.js
@@ -57,7 +57,7 @@ function resize() {
   
     // buttonBox sits below map with small vertical buffer between map and buttons
     waterUseViz.dims.buttonBox.width = waterUseViz.dims.map.width * 0.6;
-    waterUseViz.dims.buttonBox.height = waterUseViz.dims.buttonBox.width * 0.6 *
+    waterUseViz.dims.buttonBox.height = waterUseViz.dims.buttonBox.width * 0.7 *
       (waterUseViz.dims.buttonBox.heightDesktop / waterUseViz.dims.buttonBox.widthDesktop);
     waterUseViz.dims.buttonBox.x0 = (waterUseViz.dims.map.width - waterUseViz.dims.buttonBox.width) / 2; // center within svg
     waterUseViz.dims.buttonBox.y0 = waterUseViz.dims.map.height * 0.90;

--- a/js/resize.js
+++ b/js/resize.js
@@ -44,6 +44,9 @@ function resize() {
     waterUseViz.dims.buttonBox.height = waterUseViz.dims.buttonBox.heightDesktop;
     waterUseViz.dims.buttonBox.x0 = 0;
     waterUseViz.dims.buttonBox.y0 = (waterUseViz.dims.map.height/2) - (waterUseViz.dims.buttonBox.height/2);
+    // essentially how far title is from box
+    waterUseViz.dims.buttonBox.titlesHeight = waterUseViz.dims.buttonBox.height*0.22;
+    
     // map fills the full svg
     waterUseViz.dims.map.x0 = waterUseViz.dims.buttonBox.width;
     // svg is [buttons][map]
@@ -60,6 +63,9 @@ function resize() {
     waterUseViz.dims.buttonBox.height = waterUseViz.dims.buttonBox.width * 0.7 *
       (waterUseViz.dims.buttonBox.heightDesktop / waterUseViz.dims.buttonBox.widthDesktop);
     waterUseViz.dims.buttonBox.x0 = (waterUseViz.dims.map.width - waterUseViz.dims.buttonBox.width) / 2; // center within svg
+    // essentially how far title is from box
+    waterUseViz.dims.buttonBox.titlesHeight = waterUseViz.dims.buttonBox.height*0.16;
+    
     waterUseViz.dims.buttonBox.y0 = waterUseViz.dims.map.height * 0.90;
     // map fills the top part of the svg
     waterUseViz.dims.map.x0 = 0;

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -175,7 +175,7 @@
 
 /* mobile */
 .button text{
-  font-size:2em;
+  font-size:2.2em;
   dominant-baseline:central;
   pointer-events:none;
 }


### PR DESCRIPTION
The rest of #276. Moved text closer to edges on both mobile and desktop. Increased height of buttons on mobile, thus redid the spacing of the mobile title and buttons. Also, increased mobile font size because of bigger buttons.

Mobile before:
![image](https://user-images.githubusercontent.com/13220910/39642547-b75d31b6-4f97-11e8-92fb-d19ff97a596b.png)

Mobile after:
![image](https://user-images.githubusercontent.com/13220910/39642584-cccc6bf2-4f97-11e8-9f1e-dc3345f0e445.png)

Slight adjustment to desktop spacing. 
Desktop before:
![image](https://user-images.githubusercontent.com/13220910/39642524-a8fa5f18-4f97-11e8-8cc5-33315c110f97.png)

Desktop after:
![image](https://user-images.githubusercontent.com/13220910/39642511-9dcb6ae2-4f97-11e8-8193-a0b57df5f082.png)
