### PR TITLE
Mobile toposimple

### DIFF
--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -94,21 +94,21 @@ targets:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(FALSE),
-      county_topojson='target/data/county_boundaries_USA.json',
+      county_topojson='cache/pre_county_boundaries_USA.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
 
   cache/pre_state_boundaries_mobile.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(5e6), zoom_dims=I(TRUE),
-      county_topojson='target/data/county_boundaries_mobile.json',
+      county_topojson='cache/pre_county_boundaries_mobile.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js')   
 
   cache/pre_state_boundaries_zoom.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
-      county_topojson='target/data/county_boundaries_zoom.json',
+      county_topojson='cache/pre_county_boundaries_zoom.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
 
 # --- create county centroids from original sp object --- #

--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -43,7 +43,7 @@ targets:
     command: read_shp_zip('cache/pre_county_boundaries_census.zip')
     
   county_boundaries_shifted_sp:
-    command: scale_shifted_shps(county_boundaries_census_sp, STATEFP = I(c('72','78')), scale = I(3))
+    command: scale_shifted_shps(county_boundaries_census_sp, STATEFP = I(c('72','78','02')), scale = I(c(3, 3, 1/2)))
     
   cache/pre_county_dictionary.json:
     command: process_county_dictionary(target_name, county_boundaries_shifted_sp)
@@ -64,7 +64,7 @@ targets:
   cache/simpled_county_boundaries_mobile.json:
     command: process_counties(
       outfile=target_name, county_sp=county_boundaries_shifted_sp,
-      simplify=I(1e-7), quantize=I(1e7),
+      simplify=I(5e-7), quantize=I(5e6),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
   # simplify closer to 1e-20 and quantize closer to 1e20 make higher resolution boundaries (bigger files)  
@@ -76,35 +76,35 @@ targets:
 
       
 # --- shift back scales after simplication of counties --- #
-  target/data/county_boundaries_USA.json:
+  cache/pre_county_boundaries_USA.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_USA.json", STATEFP = I(c('72','78')), scale = I(1/3), quantize=I(1e6))
+      target_name, "cache/simpled_county_boundaries_USA.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), quantize=I(1e6))
 
-  target/data/county_boundaries_mobile.json:
+  cache/pre_county_boundaries_mobile.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78')), scale = I(1/3), coerce_dropped = I(TRUE), quantize=I(1e7)) 
+      target_name, "cache/simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), coerce_dropped = I(TRUE), quantize=I(1e7)) 
 
-  target/data/county_boundaries_zoom.json:
+  cache/pre_county_boundaries_zoom.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78')), scale = I(1/3), coerce_dropped = I(TRUE), quantize=I(1e8)) 
+      target_name, "cache/simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), coerce_dropped = I(TRUE), quantize=I(1e8)) 
 
 # --- use topojson versions of counties to create state boundaries --- #
 
-  target/data/state_boundaries_USA.json:
+  cache/pre_state_boundaries_USA.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(FALSE),
       county_topojson='target/data/county_boundaries_USA.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
 
-  target/data/state_boundaries_mobile.json:
+  cache/pre_state_boundaries_mobile.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e7), zoom_dims=I(TRUE),
+      outfile=target_name, objects=I('states'), quantize=I(5e6), zoom_dims=I(TRUE),
       county_topojson='target/data/county_boundaries_mobile.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js')   
 
-  target/data/state_boundaries_zoom.json:
+  cache/pre_state_boundaries_zoom.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
@@ -113,42 +113,42 @@ targets:
 
 # --- create county centroids from original sp object --- #
 
-  target/data/county_centroids_USA.json:
+  cache/pre_county_centroids_USA.json:
     command: process_compute_centroids(
-      outfile=target_name, spdat=county_boundaries_shifted_sp,
+      outfile=target_name, spdat=county_boundaries_census_sp,
       county_dict_file='cache/pre_county_dictionary.json')
   
   # --- publish --- #
   
-#  SB_county_boundaries_USA_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_USA.json", I("county_boundaries_USA.json"))
-  
-#  SB_county_boundaries_zoom_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_zoom.json", I("county_boundaries_zoom.json"))
-  
-#  SB_county_boundaries_mobile_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_mobile.json", I("county_boundaries_mobile.json"))
-  
-#  SB_state_boundaries_USA_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_USA.json", I("state_boundaries_USA.json"))
-  
-#  SB_state_boundaries_zoom_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_zoom.json", I("state_boundaries_zoom.json"))
-  
-#  SB_state_boundaries_mobile_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_mobile.json", I("state_boundaries_mobile.json"))
+  SB_county_boundaries_USA_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_USA.json", I("county_boundaries_USA.json"))
 
-#  SB_county_centroids_json:
-#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_centroids_USA.json", I("county_centroids_USA.json"))
+  SB_county_boundaries_mobile_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_mobile.json", I("county_boundaries_mobile.json"))
+    
+  SB_county_boundaries_zoom_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_zoom.json", I("county_boundaries_zoom.json"))
+
+  SB_state_boundaries_USA_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_USA.json", I("state_boundaries_USA.json"))
+  
+  SB_state_boundaries_mobile_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_mobile.json", I("state_boundaries_mobile.json"))
+
+  SB_state_boundaries_zoom_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_zoom.json", I("state_boundaries_zoom.json"))
+
+  SB_county_centroids_json:
+    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_centroids_USA.json", I("county_centroids_USA.json"))
   
   # --- final --- #
   
   preprocess:
     depends:
-      - target/data/county_boundaries_USA.json
-      - target/data/county_boundaries_zoom.json
-      - target/data/county_boundaries_mobile.json
-      - target/data/state_boundaries_USA.json
-      - target/data/state_boundaries_zoom.json
-      - target/data/state_boundaries_mobile.json
-      - target/data/county_centroids_USA.json
+      - SB_county_boundaries_USA_json
+      - SB_county_boundaries_mobile_json
+      - SB_county_boundaries_zoom_json
+      - SB_state_boundaries_USA_json
+      - SB_state_boundaries_mobile_json
+      - SB_state_boundaries_zoom_json
+      - SB_county_centroids_json

--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -7,6 +7,9 @@ packages:
   - tibble
   - sbtools
   - maptools
+  - geojsonio
+  - lwgeom
+  - sf
 
 sources:
   - scripts/preprocess/fetch_url.R
@@ -39,112 +42,113 @@ targets:
   county_boundaries_census_sp:
     command: read_shp_zip('cache/pre_county_boundaries_census.zip')
     
+  county_boundaries_shifted_sp:
+    command: scale_shifted_shps(county_boundaries_census_sp, STATEFP = I(c('72','78')), scale = I(3))
+    
   cache/pre_county_dictionary.json:
-    command: process_county_dictionary(target_name, county_boundaries_census_sp)
+    command: process_county_dictionary(target_name, county_boundaries_shifted_sp)
     
   cache/pre_state_dictionary.json:
-    command: process_state_dictionary(target_name, county_boundaries_census_sp)
-  
+    command: process_state_dictionary(target_name, county_boundaries_shifted_sp)
+
+# --- simplication of counties --- #
+
   # simplify closer to 1e-1 and quantize closer to 1e1 make smaller files
-  cache/pre_county_boundaries_USA.json:
+  cache/simpled_county_boundaries_USA.json:
     command: process_counties(
-      outfile=target_name, county_sp=county_boundaries_census_sp,
+      outfile=target_name, county_sp=county_boundaries_shifted_sp,
       simplify=I(1e-6), quantize=I(1e6),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
-  
-  cache/pre_state_boundaries_USA.json:
-    depends: scripts/preprocess/custom_projection.js
-    command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(FALSE),
-      county_topojson='cache/pre_county_boundaries_USA.json',
-      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-  
-  cache/pre_all_boundaries_USA.json:
-    depends: scripts/preprocess/custom_projection.js
-    command: process_counties_to_states(
-      outfile=target_name, objects=I('states-and-counties'), quantize=I(1e6), zoom_dims=I(FALSE),
-      county_topojson='cache/pre_county_boundaries_USA.json',
-      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-      
+
   # simplify closer to 1e-20 and quantize closer to 1e20 make higher resolution boundaries (bigger files)  
-  cache/pre_county_boundaries_zoom.json:
+  cache/simpled_county_boundaries_zoom.json:
     command: process_counties(
-      outfile=target_name, county_sp=county_boundaries_census_sp,
+      outfile=target_name, county_sp=county_boundaries_shifted_sp,
       simplify=I(1e-8), quantize=I(1e8),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
-  cache/pre_state_boundaries_zoom.json:
-    depends: scripts/preprocess/custom_projection.js
-    command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
-      county_topojson='cache/pre_county_boundaries_zoom.json',
-      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-  
-  cache/pre_all_boundaries_zoom.json:
-    depends: scripts/preprocess/custom_projection.js
-    command: process_counties_to_states(
-      outfile=target_name, objects=I('states-and-counties'), quantize=I(1e8), zoom_dims=I(FALSE),
-      county_topojson='cache/pre_county_boundaries_zoom.json',
-      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-  
   # simplify somewhere between USA and zoom top optimize for mobile
-  cache/pre_county_boundaries_mobile.json:
+  cache/simpled_county_boundaries_mobile.json:
     command: process_counties(
-      outfile=target_name, county_sp=county_boundaries_census_sp,
+      outfile=target_name, county_sp=county_boundaries_shifted_sp,
       simplify=I(1e-7), quantize=I(1e7),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
+      
+# --- shift back scales after simplication of counties --- #
+  target/data/county_boundaries_USA.json:
+    command: rescale_write_shps(
+      target_name, "cache/simpled_county_boundaries_USA.json", STATEFP = I(c('72','78')), scale = I(1/3))
+
+  target/data/county_boundaries_zoom.json:
+    command: rescale_write_shps(
+      target_name, "cache/simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78')), scale = I(1/3)) 
+
+  target/data/county_boundaries_mobile.json:
+    command: rescale_write_shps(
+      target_name, "cache/simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78')), scale = I(1/3))  
+
+# --- use topojson versions of counties to create state boundaries --- #
+
+  target/data/state_boundaries_USA.json:
+    depends: scripts/preprocess/custom_projection.js
+    command: process_counties_to_states(
+      outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(FALSE),
+      county_topojson='target/data/county_boundaries_USA.json',
+      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
   
-  cache/pre_state_boundaries_mobile.json:
+  target/data/state_boundaries_zoom.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
-      county_topojson='cache/pre_county_boundaries_mobile.json',
+      county_topojson='target/data/county_boundaries_zoom.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-  
-  cache/pre_county_centroids_USA.json:
+
+  target/data/state_boundaries_mobile.json:
+    depends: scripts/preprocess/custom_projection.js
+    command: process_counties_to_states(
+      outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
+      county_topojson='target/data/county_boundaries_mobile.json',
+      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
+
+
+# --- create county centroids from original sp object --- #
+
+  target/data/county_centroids_USA.json:
     command: process_compute_centroids(
-      outfile=target_name, spdat=county_boundaries_census_sp,
+      outfile=target_name, spdat=county_boundaries_shifted_sp,
       county_dict_file='cache/pre_county_dictionary.json')
   
   # --- publish --- #
   
-  SB_county_boundaries_USA_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_USA.json", I("county_boundaries_USA.json"))
+#  SB_county_boundaries_USA_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_USA.json", I("county_boundaries_USA.json"))
   
-  SB_county_boundaries_zoom_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_zoom.json", I("county_boundaries_zoom.json"))
+#  SB_county_boundaries_zoom_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_zoom.json", I("county_boundaries_zoom.json"))
   
-  SB_county_boundaries_mobile_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_mobile.json", I("county_boundaries_mobile.json"))
+#  SB_county_boundaries_mobile_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_boundaries_mobile.json", I("county_boundaries_mobile.json"))
   
-  SB_state_boundaries_USA_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_USA.json", I("state_boundaries_USA.json"))
+#  SB_state_boundaries_USA_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_USA.json", I("state_boundaries_USA.json"))
   
-  SB_state_boundaries_zoom_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_zoom.json", I("state_boundaries_zoom.json"))
+#  SB_state_boundaries_zoom_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_zoom.json", I("state_boundaries_zoom.json"))
   
-  SB_state_boundaries_mobile_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_mobile.json", I("state_boundaries_mobile.json"))
-  
-  SB_all_boundaries_USA_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_all_boundaries_USA.json", I("all_boundaries_USA.json"))
-  
-  SB_all_boundaries_zoom_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_all_boundaries_zoom.json", I("all_boundaries_zoom.json"))
+#  SB_state_boundaries_mobile_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_state_boundaries_mobile.json", I("state_boundaries_mobile.json"))
 
-  SB_county_centroids_json:
-    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_centroids_USA.json", I("county_centroids_USA.json"))
+#  SB_county_centroids_json:
+#    command: push_SB_object(I("5ab154b1e4b081f61ab26420"), "cache/pre_county_centroids_USA.json", I("county_centroids_USA.json"))
   
   # --- final --- #
   
   preprocess:
     depends:
-      - SB_county_boundaries_USA_json
-      - SB_county_boundaries_zoom_json
-      - SB_county_boundaries_mobile_json
-      - SB_state_boundaries_USA_json
-      - SB_state_boundaries_zoom_json
-      - SB_state_boundaries_mobile_json
-      - SB_all_boundaries_USA_json
-      - SB_all_boundaries_zoom_json
-      - SB_county_centroids_json
+      - target/data/county_boundaries_USA.json
+      - target/data/county_boundaries_zoom.json
+      - target/data/county_boundaries_mobile.json
+      - target/data/state_boundaries_USA.json
+      - target/data/state_boundaries_zoom.json
+      - target/data/state_boundaries_mobile.json
+      - target/data/county_centroids_USA.json

--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -60,6 +60,13 @@ targets:
       simplify=I(1e-6), quantize=I(1e6),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
+  # simplify somewhere between USA and zoom top optimize for mobile
+  cache/simpled_county_boundaries_mobile.json:
+    command: process_counties(
+      outfile=target_name, county_sp=county_boundaries_shifted_sp,
+      simplify=I(1e-7), quantize=I(1e7),
+      county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
+
   # simplify closer to 1e-20 and quantize closer to 1e20 make higher resolution boundaries (bigger files)  
   cache/simpled_county_boundaries_zoom.json:
     command: process_counties(
@@ -67,25 +74,19 @@ targets:
       simplify=I(1e-8), quantize=I(1e8),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
-  # simplify somewhere between USA and zoom top optimize for mobile
-  cache/simpled_county_boundaries_mobile.json:
-    command: process_counties(
-      outfile=target_name, county_sp=county_boundaries_shifted_sp,
-      simplify=I(1e-7), quantize=I(1e7),
-      county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
       
 # --- shift back scales after simplication of counties --- #
   target/data/county_boundaries_USA.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_USA.json", STATEFP = I(c('72','78')), scale = I(1/3))
-
-  target/data/county_boundaries_zoom.json:
-    command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78')), scale = I(1/3)) 
+      target_name, "cache/simpled_county_boundaries_USA.json", STATEFP = I(c('72','78')), scale = I(1/3), quantize=I(1e6))
 
   target/data/county_boundaries_mobile.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78')), scale = I(1/3))  
+      target_name, "cache/simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78')), scale = I(1/3), coerce_dropped = I(TRUE), quantize=I(1e7)) 
+
+  target/data/county_boundaries_zoom.json:
+    command: rescale_write_shps(
+      target_name, "cache/simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78')), scale = I(1/3), coerce_dropped = I(TRUE), quantize=I(1e8)) 
 
 # --- use topojson versions of counties to create state boundaries --- #
 
@@ -95,21 +96,20 @@ targets:
       outfile=target_name, objects=I('states'), quantize=I(1e6), zoom_dims=I(FALSE),
       county_topojson='target/data/county_boundaries_USA.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-  
+
+  target/data/state_boundaries_mobile.json:
+    depends: scripts/preprocess/custom_projection.js
+    command: process_counties_to_states(
+      outfile=target_name, objects=I('states'), quantize=I(1e7), zoom_dims=I(TRUE),
+      county_topojson='target/data/county_boundaries_mobile.json',
+      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js')   
+
   target/data/state_boundaries_zoom.json:
     depends: scripts/preprocess/custom_projection.js
     command: process_counties_to_states(
       outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
       county_topojson='target/data/county_boundaries_zoom.json',
       state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-
-  target/data/state_boundaries_mobile.json:
-    depends: scripts/preprocess/custom_projection.js
-    command: process_counties_to_states(
-      outfile=target_name, objects=I('states'), quantize=I(1e8), zoom_dims=I(TRUE),
-      county_topojson='target/data/county_boundaries_mobile.json',
-      state_dict_file='cache/pre_state_dictionary.json', script_file = 'scripts/preprocess/process_counties_to_states.js') 
-
 
 # --- create county centroids from original sp object --- #
 

--- a/preprocess.yaml
+++ b/preprocess.yaml
@@ -54,21 +54,21 @@ targets:
 # --- simplication of counties --- #
 
   # simplify closer to 1e-1 and quantize closer to 1e1 make smaller files
-  cache/simpled_county_boundaries_USA.json:
+  cache/pre_simpled_county_boundaries_USA.json:
     command: process_counties(
       outfile=target_name, county_sp=county_boundaries_shifted_sp,
       simplify=I(1e-6), quantize=I(1e6),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
   # simplify somewhere between USA and zoom top optimize for mobile
-  cache/simpled_county_boundaries_mobile.json:
+  cache/pre_simpled_county_boundaries_mobile.json:
     command: process_counties(
       outfile=target_name, county_sp=county_boundaries_shifted_sp,
       simplify=I(5e-7), quantize=I(5e6),
       county_dict_file='cache/pre_county_dictionary.json', script_file='scripts/preprocess/process_counties.sh')
 
   # simplify closer to 1e-20 and quantize closer to 1e20 make higher resolution boundaries (bigger files)  
-  cache/simpled_county_boundaries_zoom.json:
+  cache/pre_simpled_county_boundaries_zoom.json:
     command: process_counties(
       outfile=target_name, county_sp=county_boundaries_shifted_sp,
       simplify=I(1e-8), quantize=I(1e8),
@@ -78,15 +78,15 @@ targets:
 # --- shift back scales after simplication of counties --- #
   cache/pre_county_boundaries_USA.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_USA.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), quantize=I(1e6))
+      target_name, "cache/pre_simpled_county_boundaries_USA.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), quantize=I(1e6))
 
   cache/pre_county_boundaries_mobile.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), coerce_dropped = I(TRUE), quantize=I(1e7)) 
+      target_name, "cache/pre_simpled_county_boundaries_mobile.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), coerce_dropped = I(TRUE), quantize=I(1e7)) 
 
   cache/pre_county_boundaries_zoom.json:
     command: rescale_write_shps(
-      target_name, "cache/simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), coerce_dropped = I(TRUE), quantize=I(1e8)) 
+      target_name, "cache/pre_simpled_county_boundaries_zoom.json", STATEFP = I(c('72','78','02')), scale = I(c(1/3, 1/3, 2)), coerce_dropped = I(TRUE), quantize=I(1e8)) 
 
 # --- use topojson versions of counties to create state boundaries --- #
 

--- a/scripts/preprocess/process_counties.R
+++ b/scripts/preprocess/process_counties.R
@@ -6,8 +6,7 @@ process_counties <- function(outfile, county_sp, simplify, quantize, county_dict
   county_dict <- jsonlite::fromJSON(county_dict_file)
   county_sp@data <- county_sp@data %>%
     mutate(GEOID=as.character(GEOID)) %>%
-    left_join(county_dict, by='GEOID') %>%
-    select(GEOID, STATE_ABBV, COUNTY_LONG)
+    left_join(county_dict, by='GEOID')
   
   # define some file names
   tmp <- tempdir()

--- a/scripts/preprocess/process_zip_to_shp.R
+++ b/scripts/preprocess/process_zip_to_shp.R
@@ -129,11 +129,6 @@ rescale_write_shps <- function(filename_out, topojson_filename, ..., scale, quan
   topo_simple <- file.path(tmp, 'county_boundaries_simple.json')
   
   writeOGR(shifted_shps, geo_raw, layer = "geojson", driver = "GeoJSON", check_exists=FALSE)
-  if (topojson_filename == 'target/data/county_boundaries_zoom.json'){
-    browser()  
-  } else {
-    message(topojson_filename)
-  }
   
   system(sprintf('echo Topojsonifying...
     geo2topo counties=%s -o %s

--- a/scripts/preprocess/process_zip_to_shp.R
+++ b/scripts/preprocess/process_zip_to_shp.R
@@ -36,14 +36,21 @@ scale_shifted_shps <- function(sp, ..., scale){
     stop(args, ' was not valid')
   }
   values <- args[[1]]
-  toshift_sp <- sp[sp@data[[field]] %in% values, ]
-  toshift_cent <- rgeos::gCentroid(toshift_sp, byid=F)@coords
-  toshift_scale <- max(apply(bbox(toshift_sp), 1, diff)) * scale
-  obj <- maptools::elide(toshift_sp, scale=toshift_scale, center=toshift_cent, bb = bbox(toshift_sp))
-  new_cent <- rgeos::gCentroid(obj, byid=FALSE)@coords
-  obj <- maptools::elide(obj, shift=c(toshift_cent-new_cent))
-  proj4string(obj) <- proj4string(sp)
-  sp_out <- rbind(sp[!(sp@data[[field]] %in% values), ], obj)
+  if (length(values) != length(scale)){
+    stop('number of values in ',field,' must equal the length of scale')
+  }
+  for (i in 1:length(values)){
+    toshift_sp <- sp[sp@data[[field]] == values[i], ]
+    toshift_cent <- rgeos::gCentroid(toshift_sp, byid=F)@coords
+    toshift_scale <- max(apply(bbox(toshift_sp), 1, diff)) * scale[i]
+    obj <- maptools::elide(toshift_sp, scale=toshift_scale, center=toshift_cent, bb = bbox(toshift_sp))
+    new_cent <- rgeos::gCentroid(obj, byid=FALSE)@coords
+    obj <- maptools::elide(obj, shift=c(toshift_cent-new_cent))
+    proj4string(obj) <- proj4string(sp)
+    sp_out <- rbind(sp[!(sp@data[[field]] == values[i]), ], obj)
+    sp <- sp_out
+  }
+  
   return(sp_out)
 }
 

--- a/scripts/preprocess/process_zip_to_shp.R
+++ b/scripts/preprocess/process_zip_to_shp.R
@@ -35,6 +35,9 @@ scale_shifted_shps <- function(sp, ..., scale){
   if (length(field) != 1){
     stop(args, ' was not valid')
   }
+  # we can specify a single "field" name that is an attribute of the spatial data (e.g., STATEFP)
+  # that "field" can have multiple values (e.g, "02" and "71") that we'll apply "scale" to. 
+  # here we test that the length of "scale" is equal to the length of the values:
   values <- args[[1]]
   if (length(values) != length(scale)){
     stop('number of values in ',field,' must equal the length of scale')

--- a/scripts/preprocess/process_zip_to_shp.R
+++ b/scripts/preprocess/process_zip_to_shp.R
@@ -25,18 +25,82 @@ read_shp_zip <- function(zipfile) {
 }
 
 #' @param sp the full spatial object to be altered, w/ STATEFP attribute
-#' @param fips a character vector of fips to be scaled
+#' @param ... named character argument for fields in `sp` to be scaled
 #' @param scale a scale factor to apply to fips
 #' @return an `sp` similar to the input, but with the specified fips scaled according to `scale` parameter
-scale_shifted_shps <- function(sp, fips, scale){
+scale_shifted_shps <- function(sp, ..., scale){
   
-  toshift_sp <- sp[sp@data$STATEFP %in% fips, ]
+  args <- list(...)
+  field <- names(args)
+  if (length(field) != 1){
+    stop(args, ' was not valid')
+  }
+  values <- args[[1]]
+  toshift_sp <- sp[sp@data[[field]] %in% values, ]
   toshift_cent <- rgeos::gCentroid(toshift_sp, byid=F)@coords
   toshift_scale <- max(apply(bbox(toshift_sp), 1, diff)) * scale
   obj <- maptools::elide(toshift_sp, scale=toshift_scale, center=toshift_cent, bb = bbox(toshift_sp))
   new_cent <- rgeos::gCentroid(obj, byid=FALSE)@coords
   obj <- maptools::elide(obj, shift=c(toshift_cent-new_cent))
   proj4string(obj) <- proj4string(sp)
-  sp_out <- rbind(sp[!(sp@data$STATEFP %in% fips), ], obj)
+  sp_out <- rbind(sp[!(sp@data[[field]] %in% values), ], obj)
   return(sp_out)
+}
+
+geomcoll_to_poly <- function(sfg){
+  classes <- sapply(seq_len(length(sfg)), function(x) class(sfg[x][[1]])[2])
+  is_poly <- grepl("*POLYGON", classes)
+  if (any(is_poly)){
+    sfg[[which(is_poly)[1L]]]
+  } else {
+    NULL
+  }
+}
+
+
+rescale_write_shps <- function(filename_out, topojson_filename, ..., scale){
+  shps <- topojson_read(topojson_filename) %>% 
+    st_as_sf() %>% 
+    st_make_valid() 
+  
+  sfc_objects <- sf::st_geometry(shps)
+  
+  types <- vapply(sfc_objects, function(x) {
+    class(x)[2]
+  }, "")
+  
+  drop_counties <- grepl("*LINE", types) | grepl("*POINT", types)
+  geo_col <- grepl("*GEOMETRYCOLLECTION", types) # test that there aren't others?
+  
+  for (j in which(geo_col)){
+    sfg <- geomcoll_to_poly(sfg = sfc_objects[[j]])
+    if (!is.null(sfg)){
+      sfc_objects[[j]] <- geomcoll_to_poly(sfg = sfc_objects[[j]])
+    } else {
+      drop_counties[j] <- TRUE
+    }
+  }
+  
+  message('WARNING...dropping ', sum(drop_counties),' counties that were simplified to points or lines')
+ 
+  sp_shp <- as_Spatial(sfc_objects[!drop_counties])
+  st_geometry(shps) <- NULL
+  data_in <- shps[!drop_counties,]
+  row.names(data_in) <- row.names(sp_shp)
+  spdf_shp <- SpatialPolygonsDataFrame(sp_shp, data = data_in)
+  
+ 
+  shifted_shps <- scale_shifted_shps(spdf_shp, ..., scale = scale)
+  
+  shifted_shps@data <- shifted_shps@data  %>%
+    select(GEOID, STATE_ABBV, COUNTY_LONG)
+  
+  
+  tmp <- tempdir()
+  geo_raw <- file.path(tmp, 'county_boundaries_raw.geojson')
+  
+  writeOGR(shifted_shps, geo_raw, layer = "geojson", driver = "GeoJSON", check_exists=FALSE)
+  system(sprintf('echo Topojsonifying...
+    geo2topo counties=%s -o %s', geo_raw, filename_out))
+  
 }


### PR DESCRIPTION
fixes #316 fixes #171 

This is a little funny, but here is what happens:

1) we scale up (PR/VI) or down (AK) certain state counties by a factor
2) we simplify and quantize
3) we read in the simplified and quantized topojson, then scale back down (PR/VI) or up (AK) the counties and re-quantize and write the topojson again
4) the states are built using the geometries of the counties coming out of the previous step
5) the data are published to SB

The goal here is that things look better at the national scale and we have better load performance (win win?). Greatest file size improvement is on national view mobile, which I considered to be a priority to shrink for initial load time. 

File sizes *before* this PR:
![image](https://user-images.githubusercontent.com/2349007/39779840-f4b26712-52cf-11e8-8dcf-ede42ab4dddf.png)

File sizes *after* this PR:
![image](https://user-images.githubusercontent.com/2349007/39779883-1a5767e2-52d0-11e8-8344-eb2bdcb99f21.png)

view on beta *before* this PR:
![image](https://user-images.githubusercontent.com/2349007/39779896-26e0da98-52d0-11e8-805b-a496b49d74bd.png)

view on localhost *after* this PR:
![image](https://user-images.githubusercontent.com/2349007/39779908-32932fda-52d0-11e8-9d5c-79b2a97274c5.png)


I also included a slightly greater degree of simplification on mobile counties, which I checked out and thought looked OK. 