### PR TITLE
trying to fix clip extent for PR [probably not merging]

### DIFF
--- a/js/custom_projection.js
+++ b/js/custom_projection.js
@@ -78,7 +78,7 @@ function albersUsaTerritories() {
 
     return (y >= 0.120 && y < 0.234 && x >= -0.425 && x < -0.214 ? alaska
         : y >= 0.166 && y < 0.234 && x >= -0.214 && x < -0.115 ? hawaii
-        : y >= 0.130 && y < 0.190 && x >= 0.270 && x < 0.410 ? puertoRico
+        : y >= 0.110 && y < 0.190 && x >= 0.243 && x < 0.510 ? puertoRico
         : lower48).invert(coordinates);
 
   };
@@ -176,8 +176,8 @@ function albersUsaTerritories() {
         .stream(pointStream);
 
     puertoRicoPoint = puertoRico
-        .translate([x + 0.340 * k, y + 0.170 * k])
-        .clipExtent([[x + 0.270 * k + epsilon, y + 0.130 * k + epsilon],[x + 0.410 * k - epsilon, y + 0.190 * k - epsilon]])
+        .translate([x + 0.350 * k, y + 0.140 * k])
+        .clipExtent([[x + 0.243 * k + epsilon, y + 0.110 * k + epsilon],[x + 0.510 * k - epsilon, y + 0.190 * k - epsilon]])
         .stream(pointStream);
 
 


### PR DESCRIPTION
We were missing a tiny island off the west of PR. This code brings it back into view, but then it was overlapping FL, so I had to translate all of PR/VI to the east. Unfortunately, this was no getting cut off by a clip extent there. I tried a combo of widening the clipExtent for lower48 and puertoRico but didn't have any luck. 

I wanted to make a PR so we could return to this sometime else if we wanted to. I will leave it up for a bit and if people have an idea, then we can fix and merge. Otherwise, we aren't going to worry about it.

Here's what this code gets you (VI is slightly cut off):
![image](https://user-images.githubusercontent.com/13220910/39784896-bdb3f55e-52df-11e8-9ddc-23e15d012172.png)
