### PR TITLE
lowercase placeholder.gif

### DIFF
--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -37,8 +37,8 @@
       <div class="key-story-plot" id="national-static-pie">
         <figure class="desktop-figure">
           <picture>
-            <source class="lazy" srcset="images/placeHolder.gif" data-src="images/WU_stories_static.jpg" media="(min-width:600px)"/>
-            <source class="lazy" srcset="images/placeHolder.gif" data-src="images/WU_stories_static_mobile.jpg" media="(max-width:599px)"/>
+            <source class="lazy" srcset="images/placeholder.gif" data-src="images/WU_stories_static.jpg" media="(min-width:600px)"/>
+            <source class="lazy" srcset="images/placeholder.gif" data-src="images/WU_stories_static_mobile.jpg" media="(max-width:599px)"/>
             {{{ placeholder }}}
           </picture>
         </figure>


### PR DESCRIPTION
Try more consistent capitalization for placeholder.gif (https://github.com/USGS-VIZLAB/water-use-15/pull/326#issuecomment-389001788)