### PR TITLE
Mobile national pie map expanding text functionality

### DIFF
--- a/js/mobile_ui.js
+++ b/js/mobile_ui.js
@@ -208,10 +208,10 @@ window.addEventListener('load', function(event){
   expandInteract.onclick = function(){
     if(contentToShow.style.display === "block"){
       contentToShow.style.display="none";
-      expandInteract.innerHTML = 'Expand to read more'
+      expandInteract.innerHTML = 'Read More'
     }else{
       contentToShow.style.display="block";
-      expandInteract.innerHTML = 'Click to hide'
+      expandInteract.innerHTML = 'Hide'
     }
     
   };

--- a/js/mobile_ui.js
+++ b/js/mobile_ui.js
@@ -200,3 +200,21 @@ function resetCountySelector() {
         return i === 0; 
       });
 }
+
+//Expand National Pie Mapp mobile text
+window.addEventListener('load', function(event){
+  var expandInteract = document.getElementById('national-static-pie-mobile-interact');
+  var contentToShow = document.getElementById('national-static-pie-mobile-content');
+  expandInteract.onclick = function(){
+    if(contentToShow.style.display === "block"){
+      contentToShow.style.display="none";
+      expandInteract.innerHTML = 'Expand to read more'
+    }else{
+      contentToShow.style.display="block";
+      expandInteract.innerHTML = 'Click to hide'
+    }
+    
+  };
+});
+
+

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -7,6 +7,16 @@
 	opacity:0;
 }
 
+#national-static-pie-mobile-content{
+  display:none;
+}
+
+.readMore{
+  text-align: center;
+  color:#003366;
+  cursor:pointer;
+  
+}
 
 .mobile-UI-Container{
   display:flex;
@@ -193,6 +203,11 @@
 }
 
 @media screen and (min-width:600px){
+  
+  #national-static-pie-mobile-container{
+    display:none;
+  }
+  
   .button text{
     font-size:1.3em;
     dominant-baseline:central;

--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -70,7 +70,7 @@
           </p>
         </div>
         
-        <p id="national-static-pie-mobile-interact" class="readMore"><strong>Expand to read more</strong></p>
+        <p id="national-static-pie-mobile-interact" class="readMore"><strong>Read More</strong></p>
       
     </div>
   </div>

--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -43,7 +43,36 @@
           </picture>
         </figure>
       </div>
-    
+      
+      <div id="national-static-pie-mobile-container">
+        <div id="national-static-pie-mobile-content">
+          <p>
+          <strong>1. Public Supply</strong> water withdrawals, mostly for Domestic use, are highest in counties with large numbers of people.
+          </p>
+          <p>
+            <strong>2. Aquaculture, mining, self-supplied domestic, and livestock</strong> water uses are distributed unevenly across the US. There are large withdrawals for aquaculture along the Snake River in southern Idaho.
+          </p>
+          <p>
+            <strong>3.</strong> Larger withdrawals in Alaska in the “other” categories are for <strong>aquaculture and mining.</strong>
+          </p>
+          <p>
+            <strong>4. Irrigation</strong> occurs in most areas of the country, but is larger in areas where rainfall is insufficient to meet crop what needs, such as in the <strong>drier parts of the West</strong>. Irrigation in <strong>eastern Arkansas</strong> provides water to flood rice fields as well as supplement rainfall to other crops.
+          </p>
+          <p>
+            <strong>5. Industrial withdrawals</strong> are driven by many factors. Industrial  facilities for production of steel in Lake County, Indiana, are located on Lake Michigan, a large source of fresh water, with access to water and land transportation, and ore and coal deposits. Lake County accounts for 8% of the US industrial water withdrawals.
+          </p>
+          <p>
+            <strong>6.</strong> The Gulf Coast is another hotspot of <strong>industrial</strong> withdrawals for the chemical and petroleum industries.
+          </p>
+          <p>
+            <strong>7. Thermoelectric</strong> power plants use steam to drive turbines and generate electricity. In the <strong>eastern U.S.</strong> where water is relatively abundant, large volumes of water often are withdrawn, used once for cooling, then returned to the source a little warmer than before. In the <strong>western U.S.</strong>, cooling water is more often withdrawn and recirculated many times, so less is withdrawn overall.
+  
+          </p>
+        </div>
+        
+        <p id="national-static-pie-mobile-interact" class="readMore"><strong>Expand to read more</strong></p>
+      
+    </div>
   </div>
   
   <div class="story-three">

--- a/viz.yaml
+++ b/viz.yaml
@@ -262,7 +262,7 @@ publish:
       map_circles: map_circles
       map_states: map_states
       map_counties: "map_counties"
-      dropdown_selector: "dropdown_selector"
+      mobile_ui: "mobile_ui"
       national_pie: "national_pie"
       rank_states_utils: "rank_states_utils"
       scroll_tracking: "scroll_tracking"
@@ -279,7 +279,7 @@ publish:
     context:
       resources: ["lib_d3_js", "topojson", "header_css", "content_css", "footer_css", "socialCSS","vizlab-favicon",
                   "map_css", "custom_css", "hashes", "projection", "styles", "buttons", "resize", "map_utils",
-                  "map_states", "map_counties", "watermark_utils", "map_circles", "dropdown_selector", "modernizr",
+                  "map_states", "map_counties", "watermark_utils", "map_circles", "mobile_ui", "modernizr",
                   "lazy_loader", "national_pie", "rank_states_utils", "scroll_tracking"]
       sections: ["social", "mobile_map_ui", "map_section", "wu_story"] # adding header and footer here, doubled each on the page
       thumbnails: 
@@ -344,8 +344,8 @@ publish:
     location: "js/counties.js"
     mimetype: application/javascript
   -
-    id: dropdown_selector
-    location: "js/dropdown_selector.js"
+    id: mobile_ui
+    location: "js/mobile_ui.js"
     mimetype: application/javascript
   -
     id: modernizr
@@ -478,7 +478,7 @@ publish:
       map_circles: map_circles
       map_states: map_states
       map_counties: map_counties
-      dropdown_selector: dropdown_selector
+      mobile_ui: mobile_ui
       modernizr: modernizr
       map_section: map_section
       state_boundaries_USA: state_boundaries_USA_topojson
@@ -493,7 +493,7 @@ publish:
     context:
       resources: ["lib_d3_js", "topojson", 
                   "map_css", "custom_css", "hashes", "projection", "styles", "buttons", "resize", "map_utils",
-                  "map_states", "map_counties", "watermark_utils", "map_circles", "dropdown_selector", "modernizr"]
+                  "map_states", "map_counties", "watermark_utils", "map_circles", "mobile_ui", "modernizr"]
       embed: ["map_section"]
   -
     id: thumb-facebook


### PR DESCRIPTION
Have the text and expanding and collapsing functionality for the national pie map mobile text.

A few things to note:

I really didn't want to be loading in a tiny new JS file so did a tricky rename of the dropdown_selector.js to mobile_ui.js to allow this bit of functionality to make sense in the file.

The current functionality has no transition or fanciness.  We may want to consider using jQuery on the next viz if we want easy to implement transitions and effects as they are built in and jQuery generally cuts the amount of code to write JS down by half.  I don't think we should add it to this one as we are pretty bloated as is.

