### PR TITLE
I broke hurricane_marie; this fixes it

### DIFF
--- a/layout/templates/footer.mustache
+++ b/layout/templates/footer.mustache
@@ -45,7 +45,7 @@
         		<div class="related-item">
         		  <a href="https://owi.usgs.gov/vizlab/hurricane-maria/" target="_blank" onclick="gtag('event','outbound', 'clicked on related vizzy')">
         		    <div class="footerThumbnail">
-        		    	<img class="lazy" src="images/placeholder.gif" data-src="images/hurricane_marie.png" alt="hurricane maria viz thumb"/>
+        		    	<img class="lazy" src="images/placeholder.gif" data-src="images/hurricane_maria.png" alt="hurricane maria viz thumb"/>
         				</div>
         			  <div class="titleHandler">
         				  <a href="https://owi.usgs.gov/vizlab/hurricane-maria/" class="related-items-caption">Visualizing Hurricane Maria

--- a/viz.yaml
+++ b/viz.yaml
@@ -431,7 +431,7 @@ publish:
     mimetype: image/png
     title: "Hurricane Maria Thumbnail"
     alttext: "Hurricane Maria Thumbnail"
-    relpath: "images/hurricane_marie.png"
+    relpath: "images/hurricane_maria.png"
   -
     id: wu_story
     template: layout/templates/wu_story.mustache


### PR DESCRIPTION
I renamed hurricane_marie.png to hurricane_maria.png in a previous PR but missed a couple of spots for changing the text, so the footer image wasn't showing up. I think this PR gets us back on track.