### PR TITLE
White space

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -152,7 +152,7 @@ function customizeCaption() {
       "Click a state to zoom in, and click the same state to zoom out.";
   }
   
-  d3.select('#fig-caption p')
+  d3.select('#map-caption p')
     .text(captionText);
 }
 

--- a/js/national_pie.js
+++ b/js/national_pie.js
@@ -82,9 +82,9 @@ function loadPie() {
     return text_size;
 	}
 	
-  var width = 525,
-      height = 350,
-      radius = Math.min(width, height) / 3,
+  var width = 360,
+      height = 240,
+      radius = Math.min(width, height) / 2,
       other_cats = ["Domestic", "Livestock", "Aquaculture", "Mining"];
   
   var wu_national_no_total = waterUseViz.nationalData

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -273,7 +273,7 @@
 /* large screen definition as in main vizlab */
 @media screen and (min-width: 1024px){
   .viz-text{
-    width:600;
+    width:960px;
     margin:20px auto 0 auto;
   } 
   

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -136,6 +136,10 @@
   margin-bottom:40px;
 }
 
+.side-by-side-left{
+  padding:0 40px 0 10px;
+}
+
 #directions {
   padding-left: 20px;
   padding-right: 40px;
@@ -233,12 +237,12 @@
   }
   
   .side-by-side-left{
-    width:70%;
+    width: 50%;
   }
   
   .side-by-side-right{
-    width:30%;
-    position:relative;
+    width: 40%;
+    position: relative;
   }
   
   .pie-caption{

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -102,19 +102,15 @@
 }
 
 .viz-text ul {
-    padding-left: 20px;
-    min-height: 20px;
-    padding: 15px;
+  padding-left: 20px;
+  min-height: 20px;
+  padding: 15px;
 }
 
 #wu-story{
   background:#fff;
   min-height: 100px;
   margin-top:20px;
-}
-
-#wu-story .viz-text{
-  padding:0;
 }
 
 #wu-story p{
@@ -145,15 +141,20 @@
   padding-right: 40px;
 }
 
-#fig-caption p{
+.caption p{
   font-size:0.9em;
   font-style: italic;
-  text-align: left;
+  text-align: center;
   color: rgb(137,137,137);
+  line-height:1.5em;
+  margin-top:20px;
+  text-decoration:none;
 }
 
+.full-width,
 .key-story-plot{
-  margin:10px 0;
+  margin:10px auto;
+  padding:0 10px;
 }
 
 .key-story-plot img{
@@ -245,9 +246,14 @@
     position: relative;
   }
   
-  .pie-caption{
+  .caption p{
+    text-align: left;
+  }
+  
+  #pie-caption{
     position:absolute;
     margin:auto;
+    padding:0 0;
     top:0; bottom:0; left:0; right:0;
     height:80px;
   }
@@ -262,6 +268,20 @@
     flex:1;
   }
   
+}
+
+/* large screen definition as in main vizlab */
+@media screen and (min-width: 1024px){
+  .viz-text{
+    width:600;
+    margin:20px auto 0 auto;
+  } 
+  
+  .full-width,
+  .key-story-plot{
+    width:960px;
+    margin:10px auto;
+  }
 }
 
 /* really large desktop screens*/

--- a/layout/templates/map_section.mustache
+++ b/layout/templates/map_section.mustache
@@ -1,8 +1,8 @@
 <div class="main-svg">
 </div>
 
-<div id="fig-caption" class="viz-text">
-  <p>[Caption goes here]</p>
+<div id="map-caption" class="caption full-width">
+  <p></p>
 </div>
 
 {{{ map_script }}}

--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -1,8 +1,10 @@
-<div id="wu-story" class="viz-text">
+<div id="wu-story">
 
   <div id="main-story">
   
   <div class="story-one">
+  
+    <div class="key-story-text viz-text">
   
       <h3>How do we use water in the U.S.?</h3>
       
@@ -10,8 +12,9 @@
         We all depend on water every day, ranging from the water from our faucets, to the food we eat, to much of the electricity we use. The U.S. and its territories used nearly 322 billion gallons of water per day in 2015. This would cover the continental U.S. in about two inches of water over the course of a year. The national breakdown of water withdrawals looks like this:
           </p>
     
+    </div>
+    
       <div class="key-story-plot side-by-side">
-      
       
         <div class="side-by-side-left">
            <div class="side-by-side-figure secondary-svg"></div>
@@ -19,7 +22,7 @@
         
         <div id="national-pie" class="side-by-side-right">
         
-          <div id="fig-caption" class="pie-caption">
+          <div id="pie-caption" class="caption">
             <p>
             Each "pie slice" represents a portion of U.S. water withdrawals in 2015.
             </p>
@@ -30,12 +33,15 @@
    
   </div>
   <div class="story-two">
+
+    <div class="key-story-text viz-text">
      <p>
         Although thermoelectric and irrigation are the dominant categories nationally, the county breakdown reveals regional variation. In the map below, you can see all categories for each county at once. While you can still see that irrigation and thermoelectric are the largest, there is a striking contrast between the East &mdash; where thermoelectric is dominant &mdash; and the West &mdash; where irrigation is dominant.
       </p>
+    </div>
       
       <div class="key-story-plot" id="national-static-pie">
-        <figure class="desktop-figure">
+        <figure>
           <picture>
             <source class="lazy" srcset="images/placeholder.gif" data-src="images/WU_stories_static.jpg" media="(min-width:600px)"/>
             <source class="lazy" srcset="images/placeholder.gif" data-src="images/WU_stories_static_mobile.jpg" media="(max-width:599px)"/>
@@ -44,7 +50,7 @@
         </figure>
       </div>
       
-      <div id="national-static-pie-mobile-container">
+      <div id="national-static-pie-mobile-container" class="key-story-text viz-text">
         <div id="national-static-pie-mobile-content">
           <p>
           <strong>1. Public Supply</strong> water withdrawals, mostly for Domestic use, are highest in counties with large numbers of people.
@@ -80,9 +86,11 @@
   
   <div class="story-three">
     
+    <div class="key-story-text viz-text">
       <p>
         As a result of all these spatial differences in how we use water, total water use differs greatly among states. Can you guess where these three states rank in total water use?
       </p>
+    </div>
       
       <div class="key-story-plot secondary-svg" id="rank-states-interactive"></div>
   
@@ -90,7 +98,7 @@
   
   </div>
   
-  <div class="extras">
+  <div class="extras full-width">
     <div id="data-collection">
       <h4>Data Collection</h4>
    

--- a/viz.yaml
+++ b/viz.yaml
@@ -274,6 +274,7 @@ publish:
       county_boundaries_mobile: county_boundaries_mobile_topojson
       county_centroids_wu: "county_centroids_wu_tsv"
       wu_data_15_range:  "wu_data_15_range_json"
+      wu_data_15_sum_json: wu_data_15_sum_json
       thumb_facebook: thumb_facebook
       thumb_twitter: thumb_twitter
       thumb_landing: thumb_landing
@@ -509,6 +510,7 @@ publish:
       county_boundaries_mobile: county_boundaries_mobile_topojson
       county_centroids_wu: county_centroids_wu_tsv
       wu_data_15_range:  wu_data_15_range_json
+      wu_data_15_sum_json: wu_data_15_sum_json
       wu_state_data_json: wu_state_data_json
     context:
       resources: ["lib_d3_js", "topojson", 


### PR DESCRIPTION
Working on, and possibly resolving, #339 refine white space. @mwernimont , this is new territory to me - please check my css carefully for noob mistakes.

* reduced white space around the big pie
* experimented with making the text skinnier than the figures, but reverted (see #339 for figures explaining why)
* centered the two figure captions in mobile/skinny mode

Remaining/new issues:
* Locally I'm seeing different number rounding, compared to beta, in the county map legend. For example, the national total is xxx,xxx.0 rather than being an integer. Did I do this with my css changes?? I don't think so because I just rebuild from the master branch and am getting the same thing. Maybe it'll be different on dev.
* Internet explorer. It looks OK but has more white space around the pie map than Chrome does. @mwernimont any ideas? chrome on the left, IE on the right:
![image](https://user-images.githubusercontent.com/12039957/40209512-84b6740e-59f4-11e8-9117-0de64da9aa8b.png)