### PR TITLE
remove hovers for mobile devices

### DIFF
--- a/js/buttons.js
+++ b/js/buttons.js
@@ -41,10 +41,14 @@ function addButtons() {
       updateCategory(d.toLowerCase(), activeCategory);
     })
     .on('mouseover', function(d){
-      showCategory(d.toLowerCase(), activeCategory, action = 'mouseover');
+      if(waterUseViz.interactionMode === "tap") {
+        showCategory(d.toLowerCase(), activeCategory, action = 'mouseover');
+      }
     })
     .on('mouseout', function(d){
-      showCategory(activeCategory, d.toLowerCase(), action = 'mouseout');
+      if(waterUseViz.interactionMode === "tap") {
+        showCategory(activeCategory, d.toLowerCase(), action = 'mouseout');
+      }
     });
   
   // button category labels

--- a/js/buttons.js
+++ b/js/buttons.js
@@ -32,24 +32,24 @@ function addButtons() {
     .attr('width', waterUseViz.dims.buttonBox.width);
   
   // button rectangles for *mouse events*
-  buttons.append('rect')
+  var mouser = buttons.append('rect')
     .classed('mouser-button', true)
     .style('opacity','0')
     .style('stroke-width',1.5)
     .style('pointer-events','all')
     .on('click', function(d){
       updateCategory(d.toLowerCase(), activeCategory);
-    })
-    .on('mouseover', function(d){
-      if(waterUseViz.interactionMode === "tap") {
-        showCategory(d.toLowerCase(), activeCategory, action = 'mouseover');
-      }
-    })
-    .on('mouseout', function(d){
-      if(waterUseViz.interactionMode === "tap") {
-        showCategory(activeCategory, d.toLowerCase(), action = 'mouseout');
-      }
     });
+  
+  if(waterUseViz.interactionMode === "hover") {
+    mouser
+      .on('mouseover', function(d){
+        showCategory(d.toLowerCase(), activeCategory, action = 'mouseover');
+      })
+      .on('mouseout', function(d){
+        showCategory(activeCategory, d.toLowerCase(), action = 'mouseout');
+      });
+  }
   
   // button category labels
   buttons.append('text')

--- a/js/counties.js
+++ b/js/counties.js
@@ -121,16 +121,20 @@ function displayCountyBounds(error, activeCountyData) {
       })
       .attr('d', buildPath)
       .on("mouseover", function(d) {
-        highlightCounty(d3.select(this)); 
-        highlightCircle(d.properties, activeCategory);
-        updateLegendText(d.properties, activeCategory); 
+        if(waterUseViz.interactionMode === "tap") {
+          highlightCounty(d3.select(this)); 
+          highlightCircle(d.properties, activeCategory);
+          updateLegendText(d.properties, activeCategory); 
+        }
         // OK to use global var activeCategory which only changes on click 
         // because people won't be able to hover on tooltips at the same time as hovering buttons
       })
       .on("mouseout", function(d) { 
-        unhighlightCounty();
-        unhighlightCircle();
-        updateLegendTextToView();
+        if(waterUseViz.interactionMode === "tap") {
+          unhighlightCounty();
+          unhighlightCircle();
+          updateLegendTextToView();
+        }
       })
       .on('click', function(d,i,j) {
         

--- a/js/counties.js
+++ b/js/counties.js
@@ -112,7 +112,7 @@ function displayCountyBounds(error, activeCountyData) {
       });
     
     // enter
-    countyBounds
+    var countyMouser = countyBounds
       .enter()
       .append("path")
       .classed('county', true) // by default, county bounds not seen
@@ -120,22 +120,6 @@ function displayCountyBounds(error, activeCountyData) {
         return d.properties.GEOID;
       })
       .attr('d', buildPath)
-      .on("mouseover", function(d) {
-        if(waterUseViz.interactionMode === "tap") {
-          highlightCounty(d3.select(this)); 
-          highlightCircle(d.properties, activeCategory);
-          updateLegendText(d.properties, activeCategory); 
-        }
-        // OK to use global var activeCategory which only changes on click 
-        // because people won't be able to hover on tooltips at the same time as hovering buttons
-      })
-      .on("mouseout", function(d) { 
-        if(waterUseViz.interactionMode === "tap") {
-          unhighlightCounty();
-          unhighlightCircle();
-          updateLegendTextToView();
-        }
-      })
       .on('click', function(d,i,j) {
         
         // clicking a county on mobile has no affect on the 
@@ -163,6 +147,22 @@ function displayCountyBounds(error, activeCountyData) {
           zoomToFromState(d,i,j, d3.select(this));
         }
       });
+    
+    if(waterUseViz.interactionMode === "hover") {
+      countyMouser
+        .on("mouseover", function(d) {
+          highlightCounty(d3.select(this)); 
+          highlightCircle(d.properties, activeCategory);
+          updateLegendText(d.properties, activeCategory); 
+          // OK to use global var activeCategory which only changes on click 
+          // because people won't be able to hover on tooltips at the same time as hovering buttons
+        })
+        .on("mouseout", function(d) { 
+          unhighlightCounty();
+          unhighlightCircle();
+          updateLegendTextToView();
+        });
+    }
     
     // update
     countyBounds


### PR DESCRIPTION
Will fix #321, but don't want to close that issue until it's tested. I'm not sure the best way to test this other than to get it out on prod so that someone with an iPhone can verify the behavior is fixed. Problem was that we kept `mouseover` events active even on mobile devices and thought it wouldn't matter, but iOS apparently registers hovers. Decided to remove those and I think that will fix the weird behavior.