### PR TITLE
Five o eight

### DIFF
--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -118,8 +118,12 @@
   padding-bottom: 10px;
 }
 
-#wu-story h2{
-  margin-top:20px;
+h2{
+  font-size:1.17em;
+}
+
+h3{
+  font-size:1em;
 }
 
 .story-one,

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -149,7 +149,7 @@ h3{
   font-size:0.9em;
   font-style: italic;
   text-align: center;
-  color: rgb(137,137,137);
+  color: rgb(106,106,106);
   line-height:1.5em;
   margin-top:20px;
   text-decoration:none;

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -201,9 +201,9 @@ h3{
   pointer-events:none;
 }
 
-.extras{
+#extras{
   background:rgb(240,240,240);
-  padding:10px;
+  padding:10px 0;
 }
 
 #data-collection p,
@@ -236,9 +236,10 @@ h3{
   }
   
   .side-by-side,
-  .extras{
+  #extras{
     display:flex;
     flex-direction:row;
+    padding:10px;
   }
   
   .side-by-side-left{
@@ -276,6 +277,10 @@ h3{
 
 /* large screen definition as in main vizlab */
 @media screen and (min-width: 1024px){
+  #extras{
+    width:940px;
+  }
+  
   .viz-text{
     width:960px;
     margin:20px auto 0 auto;

--- a/layout/css/custom.css
+++ b/layout/css/custom.css
@@ -203,7 +203,7 @@ h3{
 
 #extras{
   background:rgb(240,240,240);
-  padding:10px 0;
+  padding:10px;
 }
 
 #data-collection p,

--- a/layout/templates/footer.mustache
+++ b/layout/templates/footer.mustache
@@ -32,26 +32,24 @@
         <p class="related-items-title">Related Visualizations:</p>
         <div class="related-items-container">
         		<div class="related-item">
-        		  <a href="https://owi.usgs.gov/vizlab/water-use/" target="_blank" onclick="gtag('event','outbound', 'clicked on related vizzy')">
-        		    <div class="footerThumbnail">
+      		    <div class="footerThumbnail">
+          		  <a href="https://owi.usgs.gov/vizlab/water-use/" target="_blank" onclick="gtag('event','outbound', 'clicked on related vizzy')">
         					<img class="lazy" src="images/placeholder.gif" data-src="images/water_use_thumb.png" alt="Water use viz thumb"/>
-        				</div>
+          			</a>
         			  <div class="titleHandler">
-        				  <a href="https://owi.usgs.gov/vizlab/water-use/" class="related-items-caption">Visualizing water  use by region and time
-                  </a>
+        				  <a href="https://owi.usgs.gov/vizlab/water-use/" class="related-items-caption">Visualizing water use by region and time</a>
         				</div>
-        			</a>
+      				</div>
         		</div>
         		<div class="related-item">
-        		  <a href="https://owi.usgs.gov/vizlab/hurricane-maria/" target="_blank" onclick="gtag('event','outbound', 'clicked on related vizzy')">
-        		    <div class="footerThumbnail">
+      		    <div class="footerThumbnail">
+          		  <a href="https://owi.usgs.gov/vizlab/hurricane-maria/" target="_blank" onclick="gtag('event','outbound', 'clicked on related vizzy')">
         		    	<img class="lazy" src="images/placeholder.gif" data-src="images/hurricane_maria.png" alt="hurricane maria viz thumb"/>
-        				</div>
+                </a>
         			  <div class="titleHandler">
-        				  <a href="https://owi.usgs.gov/vizlab/hurricane-maria/" class="related-items-caption">Visualizing Hurricane Maria
-                  </a>
+        				  <a href="https://owi.usgs.gov/vizlab/hurricane-maria/" class="related-items-caption">Visualizing Hurricane Maria</a>
         				</div>
-        			</a>
+      				</div>
         		</div>
       	</div>
       </div>

--- a/layout/templates/mobileMapUI.mustache
+++ b/layout/templates/mobileMapUI.mustache
@@ -4,7 +4,7 @@
       <div class="drop-down-indicator">
         {{{selectArrows}}}
       </div>
-      <select class="view-select">
+      <select title="Select a state" class="view-select">
         <option value="USA">United States</option>
       </select>
     </div>
@@ -12,7 +12,7 @@
       <div class="drop-down-indicator">
         {{{selectArrows}}}
       </div>
-      <select class="county-select">
+      <select title="Select a county" class="county-select">
         <option value="Select County">--Select County--</option>
       </select>
     </div>

--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -98,7 +98,7 @@
   
   </div>
   
-  <div class="extras full-width">
+  <div id="extras" class="full-width viz-text">
     <div id="data-collection">
       <h3>Data Collection</h3>
    

--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -59,7 +59,7 @@
             <strong>2. Aquaculture, mining, self-supplied domestic, and livestock</strong> water uses are distributed unevenly across the US. There are large withdrawals for aquaculture along the Snake River in southern Idaho.
           </p>
           <p>
-            <strong>3.</strong> Larger withdrawals in Alaska in the &#8220other&#8221 categories are for <strong>aquaculture and mining.</strong>
+            <strong>3.</strong> Larger withdrawals in Alaska in the &#8220;other&#8221; categories are for <strong>aquaculture and mining.</strong>
           </p>
           <p>
             <strong>4a. Irrigation</strong> occurs in most areas of the country, but is larger in areas where rainfall is insufficient to meet crop what needs, such as in the <strong>drier parts of the West</strong>. 

--- a/layout/templates/wu_story.mustache
+++ b/layout/templates/wu_story.mustache
@@ -6,7 +6,7 @@
   
     <div class="key-story-text viz-text">
   
-      <h3>How do we use water in the U.S.?</h3>
+      <h2>How do we use water in the U.S.?</h2>
       
       <p>
         We all depend on water every day, ranging from the water from our faucets, to the food we eat, to much of the electricity we use. The U.S. and its territories used nearly 322 billion gallons of water per day in 2015. This would cover the continental U.S. in about two inches of water over the course of a year. The national breakdown of water withdrawals looks like this:
@@ -100,7 +100,7 @@
   
   <div class="extras full-width">
     <div id="data-collection">
-      <h4>Data Collection</h4>
+      <h3>Data Collection</h3>
    
       <p>
         Every 5 years since 1950, the USGS has compiled and estimated water-use information in cooperation with State, Federal, and local agencies to document how and where we use water. This information is essential to understand how future water demands will be met, while maintaining adequate water quality and quantities for human and ecosystem needs. The fourteenth report in this series, <a href="NEEDLINK!">Estimated Use of Water in the United States in 2015</a>, was released in May of 2018, along with the <a href="NEEDLINK!">county-level data</a> which supports the publication.
@@ -111,7 +111,7 @@
     </div>
   
     <div id="references">
-      <h4>References</h4>
+      <h3>References</h3>
       
       <p>
         Dieter, C.A., Maupin, M.A., Caldwell, R.R., Harris, M.A., Ivahnenko, T.I., Lovelace, J.K., Barber, N.L., and Linsey, K.S., 2018, <i>Estimated use of water in the United States in 2015</i>: U.S. Geological Survey Circular 1441, 60? pages, <a href="https://doi.org/xxxx">https://doi.org/xxxx</a>

--- a/viz.yaml
+++ b/viz.yaml
@@ -14,9 +14,9 @@ info:
   required-packages:
     vizlab:
       repo: github
-      version: 0.3.5
+      version: 0.3.6
       name: USGS-VIZLAB/vizlab
-      ref: c0889d88e9df47dbb763be2bf335c6de8d7b57fd
+      ref: v0.3.6
     aws.s3:
       repo: CRAN
       version: 0.3.3


### PR DESCRIPTION
There were 4 508 errors and maybe 10 alerts. I got rid of all of the errors, some of which turned into alerts instead, and got rid of one additional alert.

The errors were about:
* form items (the drop-downs for selecting states and counties) needed labels or title attributes. I added title attributes.
* hrefs need either text or, if an image, alt text in the image. We had an href around a div around an image with alt text, so I moved the div to the outside so we had a div around an href around an image with alt text. this satisfied the plug-in.

The alert I fixed was about:
* we were skipping h2 and going straight to h3 and h4. i bumped up the header levels to h2 and h3, respectively, and then altered the css so the font sizes would be ~the same.

I don't think there'll be any visible changes due to the error corrections, but it does appear that I've accidentally added a little white space after "How do we use water in the U.S.?", and it's possible that there will be noticeable font differences on some browsers. I've checked Chrome and IE11 and Firefox and think the whitespace result is still OK.

One change I don't like is that IE is no longer picking up the font on the state rank game's instructions:
![image](https://user-images.githubusercontent.com/12039957/40458184-7afb81b0-5eaf-11e8-862b-ce31aee26c16.png)
The font looks fine on Chrome and Firefox, and I've tried some things but am not going to succeed in fixing the IE font without some more help or exploration.
