### PR TITLE
State link

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -102,7 +102,6 @@ if(waterUseViz.interactionMode === 'tap') {
 d3.json(stateDataFile, function(error, stateBoundsRaw) {
   if (error) throw error;
 
-
   	drawMap(stateBoundsRaw);
 });
 

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -111,9 +111,8 @@ d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {
   d3.json("data/wu_data_15_range.json", function(error, waterUseRange) {
 
     if (error) throw error;
-    // nationalRange gets used in drawMap->addStates->applyZoomAndStyle (this function) and
-    // also in fillMap->scaleCircles-update. We'll trust that this d3.json pair
-    // loads faster than the load of county_centroids_wu/wu_data_15_sum/wu_state_data below
+    // nationalRange gets used in drawMap->addStates->applyZoomAndStyle and
+    // fillMap->scaleCircles-update
     waterUseViz.nationalRange = waterUseRange;
 
     d3.json("data/wu_data_15_sum.json", function(error, waterUseNational) {

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -102,22 +102,22 @@ if(waterUseViz.interactionMode === 'tap') {
 d3.json(stateDataFile, function(error, stateBoundsRaw) {
   if (error) throw error;
 
+
+  	drawMap(stateBoundsRaw);
+});
+
+d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {
+  
+  if (error) throw error;
+
   d3.json("data/wu_data_15_range.json", function(error, waterUseRange) {
+
     if (error) throw error;
     // nationalRange gets used in drawMap->addStates->applyZoomAndStyle (this function) and
     // also in fillMap->scaleCircles-update. We'll trust that this d3.json pair
     // loads faster than the load of county_centroids_wu/wu_data_15_sum/wu_state_data below
     waterUseViz.nationalRange = waterUseRange;
 
-  	drawMap(stateBoundsRaw);
-
-  });
-});
-
-d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {
-  
-  if (error) throw error;
-  
     d3.json("data/wu_data_15_sum.json", function(error, waterUseNational) {
       
       if (error) throw error;
@@ -133,6 +133,7 @@ d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {
         
       });
     });
+  });
 });
 
 /** Functions **/

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -100,22 +100,24 @@ if(waterUseViz.interactionMode === 'tap') {
 }
 
 d3.json(stateDataFile, function(error, stateBoundsRaw) {
-	
-	if (error) throw error;
-	drawMap(stateBoundsRaw);
-	
+  if (error) throw error;
+
+  d3.json("data/wu_data_15_range.json", function(error, waterUseRange) {
+    if (error) throw error;
+    // nationalRange gets used in drawMap->addStates->applyZoomAndStyle (this function) and
+    // also in fillMap->scaleCircles-update. We'll trust that this d3.json pair
+    // loads faster than the load of county_centroids_wu/wu_data_15_sum/wu_state_data below
+    waterUseViz.nationalRange = waterUseRange;
+
+  	drawMap(stateBoundsRaw);
+
+  });
 });
 
 d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {
   
   if (error) throw error;
   
-  d3.json("data/wu_data_15_range.json", function(error, waterUseRange) {
-    
-    if (error) throw error;
-    // set up scaling for circles at national level
-    waterUseViz.nationalRange = waterUseRange;
-    
     d3.json("data/wu_data_15_sum.json", function(error, waterUseNational) {
       
       if (error) throw error;
@@ -131,7 +133,6 @@ d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {
         
       });
     });
-  });
 });
 
 /** Functions **/
@@ -197,9 +198,6 @@ function drawMap(stateBoundsRaw) {
   // add the main, active map features
   addStates(map, stateBoundsUSA);
   
-  // manipulate dropdowns
-  updateViewSelectorOptions(activeView, stateBoundsUSA);
-  addZoomOutButton(activeView);
 }
 
 function fillMap(countyCentroidData) {
@@ -213,6 +211,10 @@ function fillMap(countyCentroidData) {
 
 	countyCentroids = countyCentroidData; // had to name arg differently, otherwise error loading boundary data...
   
+  // manipulate dropdowns - selector options require countyCentroids if starting zoomed in
+  updateViewSelectorOptions(activeView, stateBoundsUSA);
+  addZoomOutButton(activeView);
+
   // update circle scale with data
   scaleCircles = scaleCircles
     .domain(waterUseViz.nationalRange);

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -101,8 +101,7 @@ if(waterUseViz.interactionMode === 'tap') {
 
 d3.json(stateDataFile, function(error, stateBoundsRaw) {
   if (error) throw error;
-
-  	drawMap(stateBoundsRaw);
+  drawMap(stateBoundsRaw);
 });
 
 d3.tsv("data/county_centroids_wu.tsv", function(error, countyCentroids) {

--- a/js/counties.js
+++ b/js/counties.js
@@ -25,6 +25,7 @@ function loadCountyBounds(state, callback) {
         
         // do the update
         callback(null, countyBoundsUSA);
+        
       });
     } else {
       callback(null, countyBoundsUSA);
@@ -47,6 +48,14 @@ function loadCountyBounds(state, callback) {
       countyBoundsZoom.set('USA', allCountiesGeo);
       
       cacheCountyBounds(state, callback);
+      
+      // make sure the styles are right. this is only important for mobile when loading
+      // into USA view such that the first call to updateCounties happens when zooming in;
+      // otherwise the styles will already be right shortly
+      if(waterUseViz.interactionMode === 'tap') {
+        applyZoomAndStyle(activeView, false);
+      }
+
     });
   } else {
     cacheCountyBounds(state, callback);

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -122,7 +122,7 @@ function updateView(newView, fireAnalytics, doTransition) {
   } 
   
   // update the geospatial data for the upcoming resolution
-  if(typeof countyCentroids !== 'undefined' && countyBoundsZoom.size > 0) {
+  if(typeof countyCentroids !== 'undefined') {
     updateCounties(activeView);
   }
   updateStates(activeView);
@@ -169,14 +169,17 @@ function applyZoomAndStyle(newView, doTransition) {
   // setup appropriate circle scaling (zoom.s === 1 for view === 'USA')
   // multiple by zoom because you want the circles to shrink on zoom 
   // so you increase the domain and the same radii value now
-  // corresponds to a smaller circle size
-  var stateZoomRatio = 0.4;
-  var newScaling = [waterUseViz.nationalRange[0]*zoom.s,
-                    waterUseViz.nationalRange[1]*zoom.s*stateZoomRatio];
-  if(scaleCircles.domain() !== newScaling) {
-    // only change circle scale if it's different
-    scaleCircles.domain(newScaling);
-    updateCircleSize(activeCategory, activeView);
+  // corresponds to a smaller circle size. only do this if we already 
+  // know the nationalRange, which is not the case when we first add states
+  if(typeof waterUseViz.nationalRange !== 'undefined') {
+    var stateZoomRatio = 0.4;
+    var newScaling = [waterUseViz.nationalRange[0]*zoom.s,
+                      waterUseViz.nationalRange[1]*zoom.s*stateZoomRatio];
+    if(scaleCircles.domain() !== newScaling) {
+      // only change circle scale if it's different
+      scaleCircles.domain(newScaling);
+      updateCircleSize(activeCategory, activeView);
+    }
   }
 
   // reset counties each time a zoom changes

--- a/js/map_utils.js
+++ b/js/map_utils.js
@@ -122,7 +122,9 @@ function updateView(newView, fireAnalytics, doTransition) {
   } 
   
   // update the geospatial data for the upcoming resolution
-  updateCounties(activeView);
+  if(typeof countyCentroids !== 'undefined' && countyBoundsZoom.size > 0) {
+    updateCounties(activeView);
+  }
   updateStates(activeView);
   
   // ensure we have the zoom parameters (they're in the state zoom data) and apply the zoom
@@ -312,35 +314,35 @@ function updateLegendTextToView() {
       .buttonBox
       .selectAll("#legend-title")
       .text("U.S. Water Withdrawals");
-  
+
     waterUseViz.elements.buttonBox
       .selectAll('.category-amount')
       .data(waterUseViz.nationalData, function(d) { return d.category; })
       .text(function(d) { return d.fancynums; });
 
-  } else {
-    
+  } else if(typeof waterUseViz.stateData.filter === 'function') {
+
    var state_data = waterUseViz.stateData
       .filter(function(d) { 
         return d.abrv === activeView; 
     });
-    
+
     waterUseViz.elements
       .buttonBox
       .selectAll("#legend-title")
       .data(state_data)
       .text(function(d) { return d.STATE_NAME + " Water Withdrawals"; });
-  
+
     waterUseViz.elements.buttonBox
       .selectAll('.category-amount')
       .data(state_data[0].use, function(d) { return d.category; })
       .text(function(d) { return d.fancynums; });
-      
+
   }
 
   if (toolTipTimer){
-      clearTimeout(toolTipTimer); // stop ga for edge states
-    }
+    clearTimeout(toolTipTimer); // stop ga for edge states
+  }
 }
 
 d3.selection.prototype.moveToFront = function() {  


### PR DESCRIPTION
Fixes #355. Changes required were:
* move `updateViewSelectorOptions()` to after `countyCentroids` has been populated
* patience in `updateView()` if `countyCentroids` or `countyBoundsZoom` haven't yet been populated
* patience in `applyZoomAndStyle()` if wu_data_15_range.json (`nationalRange`) hasn't yet been loaded
* patience in `updateLegendTextToView()` if `stateData` hasn't yet been populated

I also noticed that in mobile view, if you loaded in USA view, the first zoom in showed you a state where the county boundaries were present but the counties were white instead of gray. Subsequent times they were gray. I eventually traced this to the fact that the first call to `updateView()` cannot both load county data and then apply styles (I think this fits with stuff i recently learned about javascript event loops in https://www.udemy.com/the-complete-nodejs-developer-course-2/learn/v4/t/lecture/5525278?start=0), so I added a second call to `applyZoomAndStyle()` in `loadCountyBounds()` for this specific case.

There are several phases of viewing, zooming, rescaling lines and circles that happen when you ask to go straight to a state view, and they differ somewhat by mobile vs desktop. This could probably be tweaked, - ideally there wouldn't be any such phases - but I'm out of time and think this PR already achieves the MVP for #355 which is to make it not-broken.

![180525-state-link](https://user-images.githubusercontent.com/12039957/40565249-9d036864-6020-11e8-916c-349f2a8b7aac.gif)
![180525-state-link-desktop](https://user-images.githubusercontent.com/12039957/40565251-9f972188-6020-11e8-817b-2e1a5efe6185.gif)
