### PR TITLE
Bundle and minify CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ gifs/*.gif
 *.DS_Store
 js/all.min.js
 js/build_map.min.js
+layout/css/all.css

--- a/js/build_map.js
+++ b/js/build_map.js
@@ -59,10 +59,10 @@ readHashes();
 /** Add major svg elements and then set their sizes **/
     
 // Create container
-var container = d3.select('body div.main-svg');
+var container = d3.select('body div#mapSVG');
 
 // Create SVG and map
-var svg = d3.select(".main-svg")
+var svg = d3.select("#mapSVG")
   .append("svg")
   .attr('preserveAspectRatio', 'xMidYMid');
 

--- a/layout/templates/embed_map.mustache
+++ b/layout/templates/embed_map.mustache
@@ -1,0 +1,4 @@
+<div id=mapSVG>
+</div>
+
+{{{ map_script }}}

--- a/layout/templates/map_section.mustache
+++ b/layout/templates/map_section.mustache
@@ -1,4 +1,4 @@
-<div class="main-svg">
+<div id=mapSVG class="main-svg">
 </div>
 
 <div id="map-caption" class="caption full-width">

--- a/scripts/publish/combine_css.R
+++ b/scripts/publish/combine_css.R
@@ -1,4 +1,4 @@
-publish.combine_minify_css <- function(viz) {
+publish.combine_css <- function(viz) {
   args <- viz[["publish_args"]]
   
   # make sure to eliminate this one if it exists already

--- a/scripts/publish/combine_minify_css.R
+++ b/scripts/publish/combine_minify_css.R
@@ -1,0 +1,42 @@
+publish.combine_minify_css <- function(viz) {
+  args <- viz[["publish_args"]]
+  
+  # make sure to eliminate this one if it exists already
+  if(file.exists(viz[["location"]])) { 
+    file.remove(viz[["location"]])
+  }
+  
+  # combine
+  file_connection <- file(viz[["location"]])
+  
+  # first add vizlab resource css
+  for(lib in args[["lib_css"]]) {
+    lib_viz <- as.viz(lib)
+    publish(lib)
+    lib_fp <- paste0(exportLocation(), lib_viz[["location"]])
+    css_f <- readLines(lib_fp)
+    write(css_f, viz[["location"]], append = TRUE)
+    file.remove(lib_fp)
+  }
+  
+  # then add cutom css for this viz
+  for(fp in args[["custom_css_files"]]) {
+    css_f <- readLines(fp)
+    write(css_f, viz[["location"]], append = TRUE)
+  }
+  
+  close(file_connection)
+  
+  # minify css using node r.js
+  # cmd <- sprintf('node r.js -o cssIn=%s out=%s', viz[["location"]], viz[["location"]])
+  # system(paste('bash', cmd))
+  
+  # publish single js file
+  
+  # create viz-like item to use in publish
+  viz_css <- list(location = viz[["location"]], mimetype = "text/css")
+  
+  # use publisher to follow typical css publishing steps to get file to target
+  vizlab::publish(viz_css)
+  
+}

--- a/scripts/publish/combine_minify_css.R
+++ b/scripts/publish/combine_minify_css.R
@@ -28,6 +28,8 @@ publish.combine_minify_css <- function(viz) {
   close(file_connection)
   
   # minify css using node r.js
+    # Couldn't get this to work inside of this framework and it only
+    # decreased size by 1KB, so not pursuing any further.
   # cmd <- sprintf('node r.js -o cssIn=%s out=%s', viz[["location"]], viz[["location"]])
   # system(paste('bash', cmd))
   

--- a/viz.yaml
+++ b/viz.yaml
@@ -301,8 +301,8 @@ publish:
     publish_args:
       lib_css: ["lib-header-css", "lib-footer-css", "lib-content-css", "lib-social-media-css"]
       custom_css_files: ["layout/css/map.css", "layout/css/custom.css"]
-    publisher: combine_minify_css
-    scripts: [scripts/publish/combine_minify_css.R]
+    publisher: combine_css
+    scripts: [scripts/publish/combine_css.R]
   -
     id: selectArrows
     location: images/selectArrows.svg

--- a/viz.yaml
+++ b/viz.yaml
@@ -325,6 +325,14 @@ publish:
     context:
       map_script: map_script
   -
+    id: embed_map
+    template: layout/templates/embed_map.mustache
+    publisher: section
+    depends:
+      map_script: build_map_minified
+    context:
+      map_script: map_script
+  -
     id: static_story_figure
     location: "images/WU_stories_static.jpg"
     mimetype: image/jpg
@@ -420,7 +428,7 @@ publish:
       topojson: topojson
       all_css: all_css
       all_js_minified: all_js_minified
-      map_section: map_section
+      embed_map: embed_map
       state_boundaries_USA: state_boundaries_USA_topojson
       state_boundaries_zoom: state_boundaries_zoom_topojson
       state_boundaries_mobile: state_boundaries_mobile_topojson
@@ -433,7 +441,7 @@ publish:
       wu_state_data_json: wu_state_data_json
     context:
       resources: ["lib_d3_js", "topojson", "all_css", "all_js_minified"]
-      embed: ["map_section"]
+      embed: ["embed_map"]
   -
     id: thumb_facebook
     publisher: thumbnail

--- a/viz.yaml
+++ b/viz.yaml
@@ -240,20 +240,15 @@ publish:
     depends:
       lib_d3_js: "lib-d3-js"
       topojson: "topojson"
-      header_css: "lib-header-css"
-      footer_css: "lib-footer-css"
-      content_css: "lib-content-css"
       vizlab-favicon: "lib-vizlab-favicon"
-      map_css: "map_css"
-      custom_css: "custom_css"
+      all_css: "all_css"
       social: "social_section"
-      socialCSS: "lib-social-media-css"
       header: "header_section"
       mobile_map_ui: "mobile_map_ui"
       map_section: "map_section"
       wu_story: "wu_story"
       footer: "footer_section"
-      all_minified: "all_minified"
+      all_js_minified: "all_js_minified"
       state_boundaries_USA: state_boundaries_USA_topojson
       state_boundaries_zoom: state_boundaries_zoom_topojson
       state_boundaries_mobile: state_boundaries_mobile_topojson
@@ -268,8 +263,7 @@ publish:
       thumb_landing: thumb_landing
       wu_state_data_json: wu_state_data_json
     context:
-      resources: ["lib_d3_js", "topojson", "header_css", "content_css", "footer_css", 
-                  "socialCSS","vizlab-favicon", "map_css", "custom_css", "all_minified"]
+      resources: ["lib_d3_js", "topojson", "vizlab-favicon", "all_css", "all_js_minified"]
       sections: ["social", "mobile_map_ui", "map_section", "wu_story"] # adding header and footer here, doubled each on the page
       thumbnails: 
         twitter: thumb_twitter
@@ -280,7 +274,7 @@ publish:
     location: "js/topojson.v1.min.js"
     mimetype: application/javascript
   -
-    id: all_minified
+    id: all_js_minified
     location: "js/all.min.js"
     mimetype: application/javascript
     publish_args:
@@ -301,13 +295,14 @@ publish:
     publisher: combine_minify_js
     scripts: [scripts/publish/combine_minify_js.R]
   -
-    id: map_css
-    location: "layout/css/map.css"
-    mimetype: text/css
-  -
-    id: custom_css
-    location: "layout/css/custom.css"
-    mimetype: text/css
+    id: all_css
+    location: "layout/css/all.css"
+    mimetype: application/javascript
+    publish_args:
+      lib_css: ["lib-header-css", "lib-footer-css", "lib-content-css", "lib-social-media-css"]
+      custom_css_files: ["layout/css/map.css", "layout/css/custom.css"]
+    publisher: combine_minify_css
+    scripts: [scripts/publish/combine_minify_css.R]
   -
     id: selectArrows
     location: images/selectArrows.svg
@@ -396,7 +391,6 @@ publish:
       logo: lib-vizlab-logo
       usgsLogo: lib-usgs-logo
       github-logo: lib-github-logo
-      css: lib-footer-css
       placeholder: placeholder
       water_use_thumb: "water_use_thumb"
       hurricane_maria_thumb: "hurricane_maria_thumb"
@@ -406,7 +400,6 @@ publish:
       usgsLogo: usgsLogo
       github-url:
       github-logo: github-logo
-      resources: [ "css" ]
       water_use_thumb: "water_use_thumb"
       hurricane_maria_thumb: "hurricane_maria_thumb"
   -
@@ -425,9 +418,8 @@ publish:
     depends:
       lib_d3_js: lib-d3-js
       topojson: topojson
-      map_css: map_css
-      custom_css: custom_css
-      all_minified: all_minified
+      all_css: all_css
+      all_js_minified: all_js_minified
       map_section: map_section
       state_boundaries_USA: state_boundaries_USA_topojson
       state_boundaries_zoom: state_boundaries_zoom_topojson
@@ -440,7 +432,7 @@ publish:
       wu_data_15_sum_json: wu_data_15_sum_json
       wu_state_data_json: wu_state_data_json
     context:
-      resources: ["lib_d3_js", "topojson", "map_css", "custom_css", "all_minified"]
+      resources: ["lib_d3_js", "topojson", "all_css", "all_js_minified"]
       embed: ["map_section"]
   -
     id: thumb_facebook


### PR DESCRIPTION
Fixes #336.

Bundled them up into one file (goes from 13.5KB for 6 files to 12KB for 1), but does not minify. I tried minifying manually using requireJS, but it only removed 1KB (I followed http://requirejs.org/docs/optimization.html#onecss) so I'm not going to worry about getting it hooked up.

Another side effect was that the embed fig wasn't getting the correct CSS and now it is since they are all bundled.

Currently:
![image](https://user-images.githubusercontent.com/13220910/40858513-17a0d538-65a4-11e8-8386-b990bbbd527f.png)

This PR:
![image](https://user-images.githubusercontent.com/13220910/40858542-351aae90-65a4-11e8-9d77-26ab604f9a98.png)
