### PR TITLE
bump circle size back down because path issue

### DIFF
--- a/js/build_map.js
+++ b/js/build_map.js
@@ -50,7 +50,7 @@ var buildPath = d3.geoPath()
 
 // circle scale
 var scaleCircles = d3.scaleSqrt()
-  .range([0, 15]);
+  .range([0, 12]);
   
 /** Get user view preferences **/
 


### PR DESCRIPTION
Last minute check on my phone and circles weren't showing up for some states in total view. California showed the circles, but then Wyoming and New Mexico did not. It felt like the exact symptoms we were bumping up against when we had to split the paths - almost like it was not able to display as many pixels as it required for one path? We really need to investigate this issue if we are going to use paths as a solution for lots of dots in the future.

Quick fix was to try dropping the size down again. I'm going to push to beta and test.