### PR TITLE
get static pie figure back

### DIFF
--- a/piemap.yaml
+++ b/piemap.yaml
@@ -23,10 +23,10 @@ targets:
       - figures/national_pies.png
   
   plot_metadata:
-    command: list(width = I(7), height = I(4.3), res = I(500), units = I("in"), 
+    command: list(width = I(24), height = I(13.5), res = I(600), units = I("in"), 
                   bg = I("white"), stateborder = I("grey50"),
                   countyborder = I("grey94"), countyfill = I("grey90"),
-                  stateborderwidth = I(0.2))
+                  stateborderwidth = I(0.8))
   
   county_dots:
     command: get_dots('cache/county_centroids_USA.json', 'cache/county_centroids_wu.tsv')

--- a/scripts/piemap/draw_utils.R
+++ b/scripts/piemap/draw_utils.R
@@ -8,7 +8,7 @@ make_arc <- function(x0, y0, r, from_angle, to_angle){
 }
 
 
-plot_national_pies <- function(us_states, us_dots, metadata, filename, watermark_file = NULL){
+plot_national_pies <- function(us_states, us_counties, us_dots, metadata, filename, watermark_file = NULL){
   
   if(is.null(metadata$units)) { metadata$units <- "px" }
   
@@ -17,9 +17,11 @@ plot_national_pies <- function(us_states, us_dots, metadata, filename, watermark
   
   plot(us_states, col = metadata$countyfill, border = metadata$countyfill, lwd = metadata$height*0.0004)
   
+  plot(us_counties, col = metadata$countyfill, border = metadata$countyborder, lwd = 0.5, add = TRUE)
+  
   if(!is.null(watermark_file)) { add_watermark(watermark_file, metadata$watermark_bump_frac) }
   
-  plot_dot(us_dots)
+  dot_to_pie(us_dots)
   
   dev.off()
 }
@@ -35,16 +37,18 @@ cat_title <- function(cat){
 }
 
 cat_col <- function(cat){
-  cols <- c("total"='#b9edf9CC')#rgb(38, 140, 178, alpha = 200, maxColorValue = 255))
+  cols <- c("irrigation" = "#59a14f", "industrial"="#e15759", 
+            "thermoelectric"="#edc948", "publicsupply"="#76b7b2", "other"="#A9A9A9", 
+            "dead"='#dcdcdc', 'text'= '#A9A9A9')#rgb(38, 140, 178, alpha = 200, maxColorValue = 255))
   cols[[cat]]
 }
 
 fill_col <- function(col){
-  col#paste0(col, 'CC')
+  paste0(col, 'CC')
 }
 
 
-plot_dot <- function(dots, scale_const = 1500){
+dot_to_pie <- function(dots, scale_const = 1500){
   
   categories <- categories()
   
@@ -55,8 +59,24 @@ plot_dot <- function(dots, scale_const = 1500){
     
     c.x <- dot@coords[1]
     c.y <- dot@coords[2]
-    if (r > 0 & !is.na(r)){
-      plot_slice(c.x, c.y, r = r, 0, 2*pi, 'total')
+    
+    for (cat in categories){
+      cat_angle <- dot[[cat]] / dot[['total']]*2*pi
+      if (cat == head(categories, 1L)){
+        # start the first category mirror relative to the top
+        angle_from <- pi/2 - cat_angle/2
+        orig_ang <- angle_from
+      } else {
+        angle_from <- angle_to
+      }
+      angle_to <- angle_from + cat_angle
+      if (!is.na(cat_angle) & cat_angle > 0.01){
+        plot_slice(c.x, c.y, r = r, angle_from, angle_to, cat)
+      }
+    }
+    
+    if (r > 0 & !is.na(r) & cat == tail(categories, 1L) & angle_to < 2*pi + orig_ang){
+      plot_slice(c.x, c.y, r = r, angle_to, 2*pi + orig_ang, 'other')
     }
   }
 }
@@ -69,6 +89,7 @@ plot_slice <- function(x,y,r,angle_from, angle_to, cat, col = NULL){
   polygon(c(x, segments$x, x), c(y, segments$y, y), 
           border = NA,
           col = fill_col(col))
+  lines(segments$x, segments$y, lwd=0.4, col = col)
 }
 
 add_watermark <- function(watermark_file, watermark_bump_frac, ...){


### PR DESCRIPTION
We lost this around the time we made the blackout thumbnails with the blue solid circles. We need to make a higher resolution one, so I updated the `piemap.yaml` code to do so. Increasing the lwd seems to make windows render of this slightly more crisp, but I still think macs can do better.

![national_pies](https://user-images.githubusercontent.com/13220910/48583939-17906680-e8ee-11e8-8fa3-943effac28b2.png)
